### PR TITLE
Use code blocks instead of inline-sourcecode

### DIFF
--- a/tutorial/setup/self-hosting.md
+++ b/tutorial/setup/self-hosting.md
@@ -42,15 +42,18 @@ Make sure to install all dependencies by running `pip install --user -r requirem
 
 Before the server can be started, you have to build the client.
 This is done by the Node.js package manager *npm* with the following command:  
-    npm i
-    npm run build
+```bash
+npm i
+npm run build```
 
 To run the server you now simply run `python3 planarserver.py` and your server should start up.
 
 In case you want to install and run the server in debug/development mode, you need to run:  
-    npm i
-    npm run serve
-    python3 planarserver.py dev
+```bash
+npm i
+npm run serve
+python3 planarserver.py dev```
+
 This starts the server in a 'hot module reloading' mode that builds changes made to the sourcecode on the fly instead of waiting for you to manually rebuild.
 
 If everything went well you should now be able to visit `http://localhost:8000` and be greeted with the login screen.
@@ -63,14 +66,15 @@ You can grab the [Official Container](https://hub.docker.com/r/kruptein/planaral
 `docker pull kruptein/planarally`
 
 Generally for ease of backup it is recommended to use [volumes](https://docs.docker.com/storage/volumes/) with docker as well.  
-    docker volume create data
-    docker volume create assets
+```bash
+docker volume create data
+docker volume create assets```
 Both of those commands will create folders in /var/lib/docker/volumes/ then you can use this next command to start the container  
 `docker run -d -t -p 8000:8000 -v data:/planarally/data/ -v assets:/planarally/static/assets/ --name planarally kruptein/planarally`
 
-then just like it was mentioned in the section above you can just type `http://localhost:8000` and access planarally
+then just like it was mentioned in the section above you can just type `http://localhost:8000` and access planarally.
 
-You can find a write up [here](https://github.com/edmael/selfhosted-planarally) written by a community member on setting up a server with SSL encryption using an nginx reverse proxy as well as docker-compose
+See also this [write up on setting up a server with SSL encryption written by a community member](https://github.com/edmael/selfhosted-planarally) using an nginx reverse proxy as well as docker-compose.
 
 ## Backups
 

--- a/tutorial/setup/self-hosting.md
+++ b/tutorial/setup/self-hosting.md
@@ -42,15 +42,15 @@ Make sure to install all dependencies by running `pip install --user -r requirem
 
 Before the server can be started, you have to build the client.
 This is done by the Node.js package manager *npm* with the following command:  
-`npm i`  
-`npm run build`
+    npm i
+    npm run build
 
 To run the server you now simply run `python3 planarserver.py` and your server should start up.
 
 In case you want to install and run the server in debug/development mode, you need to run:  
-`npm i`  
-`npm run serve`  
-`python3 planarserver.py dev`  
+    npm i
+    npm run serve
+    python3 planarserver.py dev
 This starts the server in a 'hot module reloading' mode that builds changes made to the sourcecode on the fly instead of waiting for you to manually rebuild.
 
 If everything went well you should now be able to visit `http://localhost:8000` and be greeted with the login screen.
@@ -63,8 +63,8 @@ You can grab the [Official Container](https://hub.docker.com/r/kruptein/planaral
 `docker pull kruptein/planarally`
 
 Generally for ease of backup it is recommended to use [volumes](https://docs.docker.com/storage/volumes/) with docker as well.  
-`docker volume create data`  
-`docker volume create assets`  
+    docker volume create data
+    docker volume create assets
 Both of those commands will create folders in /var/lib/docker/volumes/ then you can use this next command to start the container  
 `docker run -d -t -p 8000:8000 -v data:/planarally/data/ -v assets:/planarally/static/assets/ --name planarally kruptein/planarally`
 

--- a/tutorial/setup/self-hosting.md
+++ b/tutorial/setup/self-hosting.md
@@ -44,7 +44,8 @@ Before the server can be started, you have to build the client.
 This is done by the Node.js package manager *npm* with the following command:  
 ```bash
 npm i
-npm run build```
+npm run build
+```
 
 To run the server you now simply run `python3 planarserver.py` and your server should start up.
 
@@ -52,7 +53,8 @@ In case you want to install and run the server in debug/development mode, you ne
 ```bash
 npm i
 npm run serve
-python3 planarserver.py dev```
+python3 planarserver.py dev
+```
 
 This starts the server in a 'hot module reloading' mode that builds changes made to the sourcecode on the fly instead of waiting for you to manually rebuild.
 
@@ -68,7 +70,8 @@ You can grab the [Official Container](https://hub.docker.com/r/kruptein/planaral
 Generally for ease of backup it is recommended to use [volumes](https://docs.docker.com/storage/volumes/) with docker as well.  
 ```bash
 docker volume create data
-docker volume create assets```
+docker volume create assets
+```
 Both of those commands will create folders in /var/lib/docker/volumes/ then you can use this next command to start the container  
 `docker run -d -t -p 8000:8000 -v data:/planarally/data/ -v assets:/planarally/static/assets/ --name planarally kruptein/planarally`
 


### PR DESCRIPTION
The setup-tutorial uses some codeblocks. As they're defined as inline sourcecode, line-breaks are done with double spaces that are not always visually clear.

Markdown provides a markup for code blocks that, using an indention by four spaces on the beginning of each line, is visually clear and also, semantically, better suited for the task. So it should be used instead of separate lines of inline-sourcode. :)