### PR TITLE
Quick fix: include fa-compass

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import Card from '~/components/Card'
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { config, library } from '@fortawesome/fontawesome-svg-core'
-import { faWindowClose } from '@fortawesome/free-regular-svg-icons'
+import { faCompass, faWindowClose } from '@fortawesome/free-regular-svg-icons'
 import {
 	faChevronRight,
 	faEye,
@@ -23,6 +23,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css'
 config.autoAddCss = false;
 library.add(
 	faChevronRight,
+	faCompass,
 	faEye,
 	faStopwatch,
 	faSyncAlt,


### PR DESCRIPTION
Include the font-awesome compass icon, I forgot to include, earlier.