### PR TITLE
Add mention of X-Forwarded-Proto in reverse proxy documentation

### DIFF
--- a/src/pages/server/advanced/proxy.md
+++ b/src/pages/server/advanced/proxy.md
@@ -37,6 +37,7 @@ server {
 
     location /socket.io/ {
       proxy_http_version 1.1;
+      proxy_set_header X-Forwarded-Proto "https";
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_set_header Host $host;


### PR DESCRIPTION
src/pages/server/setup/self-hosting.mdx makes reference of X-Forwarded-Proto in traefik, but the Nginx reverse proxy documentation doesn't mention this required request header:

https://github.com/Kruptein/planarally-docs/blob/ac28c06c7688a275a701f181ad0b21b87cb75ee9/src/pages/server/setup/self-hosting.mdx?plain=1#L174

This pull request is meant to synchronise the requirement in the reverse proxy section.