### PR TITLE
chore(deps): Update most dependencies to the latest version

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,6 +31,13 @@ export default defineConfig({
         ],
     },
     vite: {
+        css: {
+            preprocessorOptions: {
+                scss: {
+                    api: "modern-compiler",
+                },
+            },
+        },
         plugins: [Icons({})],
         ssr: {
             external: ["@fortawesome/fontawesome-svg-core", "@fortawesome/free-solid-svg-icons"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,34 @@
 {
-    "name": "@example/starter",
+    "name": "@planarally/docs",
     "version": "0.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@example/starter",
+            "name": "@planarally/docs",
             "version": "0.0.1",
             "dependencies": {
-                "@astrojs/mdx": "^3.0.0",
+                "@astrojs/mdx": "^3.1.7",
                 "bufferutil": "^4.0.8",
-                "dayjs": "^1.11.11",
+                "dayjs": "^1.11.13",
                 "medium-zoom": "^1.1.0",
                 "rehype-autolink-headings": "^7.1.0",
                 "rehype-slug": "^6.0.0",
                 "remark-directive": "^3.0.0",
-                "sharp": "^0.33.4"
+                "sharp": "^0.33.5"
             },
             "devDependencies": {
-                "@astrojs/vue": "^4.2.0",
-                "@iconify/json": "^2.2.211",
-                "astro": "^4.8.6",
+                "@astrojs/vue": "^4.5.1",
+                "@iconify/json": "^2.2.252",
+                "astro": "^4.15.9",
                 "eslint": "^8.56.0",
                 "eslint-config-prettier": "^9.1.0",
-                "eslint-plugin-vue": "^9.26.0",
-                "prettier": "^3.2.5",
-                "prettier-plugin-astro": "^0.13.0",
-                "sass": "^1.77.2",
-                "unplugin-icons": "^0.19.0",
-                "vue": "^3.4.27"
+                "eslint-plugin-vue": "^9.28.0",
+                "prettier": "^3.3.3",
+                "prettier-plugin-astro": "^0.14.1",
+                "sass-embedded": "^1.79.3",
+                "unplugin-icons": "^0.19.3",
+                "vue": "^3.5.8"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -41,425 +41,93 @@
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@antfu/install-pkg": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.3.3.tgz",
-            "integrity": "sha512-nHHsk3NXQ6xkCfiRRC8Nfrg8pU5kkr3P3Y9s9dKqiuRmBD0Yap7fymNDjGFKeWhZQHqqbCS5CfeMy9wtExM24w==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
+            "integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
             "dev": true,
             "dependencies": {
-                "@jsdevtools/ez-spawn": "^3.0.4"
+                "package-manager-detector": "^0.2.0",
+                "tinyexec": "^0.3.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@antfu/utils": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.8.tgz",
-            "integrity": "sha512-rWQkqXRESdjXtc+7NRfK9lASQjpXJu1ayp7qi1d23zZorY+wBHVLHHoVcMsEnkqEBWTFqbztO7/QdJFzyEcLTg==",
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
+            "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@astrojs/compiler": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.8.0.tgz",
-            "integrity": "sha512-yrpD1WRGqsJwANaDIdtHo+YVjvIOFAjC83lu5qENIgrafwZcJgSXDuwVMXOgok4tFzpeKLsFQ6c3FoUdloLWBQ=="
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
+            "integrity": "sha512-bL/O7YBxsFt55YHU021oL+xz+B/9HvGNId3F9xURN16aeqDK9juHGktdkCSXz+U4nqFACq6ZFvWomOzhV+zfPw=="
         },
         "node_modules/@astrojs/internal-helpers": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.0.tgz",
-            "integrity": "sha512-6B13lz5n6BrbTqCTwhXjJXuR1sqiX/H6rTxzlXx+lN1NnV4jgnq/KJldCQaUWJzPL5SiWahQyinxAbxQtwgPHA=="
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.1.tgz",
+            "integrity": "sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g=="
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-5.1.0.tgz",
-            "integrity": "sha512-S6Z3K2hOB7MfjeDoHsotnP/q2UsnEDB8NlNAaCjMDsGBZfTUbWxyLW3CaphEWw08f6KLZi2ibK9yC3BaMhh2NQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-5.2.0.tgz",
+            "integrity": "sha512-vWGM24KZXz11jR3JO+oqYU3T2qpuOi4uGivJ9SQLCAI01+vEkHC60YJMRvHPc+hwd60F7euNs1PeOEixIIiNQw==",
             "dependencies": {
-                "@astrojs/prism": "^3.1.0",
+                "@astrojs/prism": "3.1.0",
                 "github-slugger": "^2.0.0",
-                "hast-util-from-html": "^2.0.0",
-                "hast-util-to-text": "^4.0.0",
-                "import-meta-resolve": "^4.0.0",
+                "hast-util-from-html": "^2.0.1",
+                "hast-util-to-text": "^4.0.2",
+                "import-meta-resolve": "^4.1.0",
                 "mdast-util-definitions": "^6.0.0",
                 "rehype-raw": "^7.0.0",
                 "rehype-stringify": "^10.0.0",
                 "remark-gfm": "^4.0.0",
                 "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.0.0",
-                "remark-smartypants": "^2.0.0",
-                "shiki": "^1.1.2",
-                "unified": "^11.0.4",
+                "remark-rehype": "^11.1.0",
+                "remark-smartypants": "^3.0.2",
+                "shiki": "^1.10.3",
+                "unified": "^11.0.5",
                 "unist-util-remove-position": "^5.0.0",
                 "unist-util-visit": "^5.0.0",
-                "unist-util-visit-parents": "^6.0.0",
-                "vfile": "^6.0.1"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@types/nlcst": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.4.tgz",
-            "integrity": "sha512-ABoYdNQ/kBSsLvZAekMhIPMQ3YUZvavStpKYs7BjLLuKVmIMA0LUgZ7b54zzuWJRbHF80v1cNf4r90Vd6eMQDg==",
-            "dependencies": {
-                "@types/unist": "^2"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/@types/unist": {
-            "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-            "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/nlcst-to-string": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.1.tgz",
-            "integrity": "sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==",
-            "dependencies": {
-                "@types/nlcst": "^1.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/parse-latin": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.1.tgz",
-            "integrity": "sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==",
-            "dependencies": {
-                "nlcst-to-string": "^3.0.0",
-                "unist-util-modify-children": "^3.0.0",
-                "unist-util-visit-children": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/remark-smartypants": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-2.1.0.tgz",
-            "integrity": "sha512-qoF6Vz3BjU2tP6OfZqHOvCU0ACmu/6jhGaINSQRI9mM7wCxNQTKB3JUAN4SVoN2ybElEDTxBIABRep7e569iJw==",
-            "dependencies": {
-                "retext": "^8.1.0",
-                "retext-smartypants": "^5.2.0",
-                "unist-util-visit": "^5.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
-            "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
-            "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "retext-latin": "^3.0.0",
-                "retext-stringify": "^3.0.0",
-                "unified": "^10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-latin": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
-            "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
-            "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "parse-latin": "^5.0.0",
-                "unherit": "^3.0.0",
-                "unified": "^10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-latin/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-latin/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-smartypants": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-5.2.0.tgz",
-            "integrity": "sha512-Do8oM+SsjrbzT2UNIKgheP0hgUQTDDQYyZaIY3kfq0pdFzoPk+ZClYJ+OERNXveog4xf1pZL4PfRxNoVL7a/jw==",
-            "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "nlcst-to-string": "^3.0.0",
-                "unified": "^10.0.0",
-                "unist-util-visit": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-smartypants/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-smartypants/node_modules/unist-util-visit": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-            "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0",
-                "unist-util-visit-parents": "^5.1.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-smartypants/node_modules/unist-util-visit-parents": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-smartypants/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-stringify": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
-            "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
-            "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "nlcst-to-string": "^3.0.0",
-                "unified": "^10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-stringify/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext-stringify/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext/node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "bail": "^2.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^4.0.0",
-                "trough": "^2.0.0",
-                "vfile": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/retext/node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/unist-util-is": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-            "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/unist-util-modify-children": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.1.1.tgz",
-            "integrity": "sha512-yXi4Lm+TG5VG+qvokP6tpnk+r1EPwyYL04JWDxLvgvPV40jANh7nm3udk65OOWquvbMDe+PL9+LmkxDpTv/7BA==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "array-iterate": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/unist-util-stringify-position": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/unist-util-visit-children": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-2.0.2.tgz",
-            "integrity": "sha512-+LWpMFqyUwLGpsQxpumsQ9o9DG2VGLFrpz+rpVXYIEdPy57GSy5HioC0g3bg/8WP9oCLlapQtklOzQ8uLS496Q==",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@astrojs/markdown-remark/node_modules/vfile-message": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
+                "unist-util-visit-parents": "^6.0.1",
+                "vfile": "^6.0.2"
             }
         },
         "node_modules/@astrojs/mdx": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-3.0.0.tgz",
-            "integrity": "sha512-t1x+fmRA7w/AUWEhvWsMjw8op29mkzkpLN+AfsrtIAnGCf5y3NhcDwamKBvHDUTw/SdM3dn0JMi+JGaGnocDmw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-3.1.7.tgz",
+            "integrity": "sha512-8lGdCt+S0TrZgQpbcP3fQJc4cTeacAirtz9TpAMtHCWrQGW8slKt3WG4/0N+bhZgYRC4h5AT5drzFz+y3wvmsg==",
             "dependencies": {
-                "@astrojs/markdown-remark": "5.1.0",
+                "@astrojs/markdown-remark": "5.2.0",
                 "@mdx-js/mdx": "^3.0.1",
-                "acorn": "^8.11.3",
-                "es-module-lexer": "^1.5.2",
+                "acorn": "^8.12.1",
+                "es-module-lexer": "^1.5.4",
                 "estree-util-visit": "^2.0.0",
-                "github-slugger": "^2.0.0",
                 "gray-matter": "^4.0.3",
-                "hast-util-to-html": "^9.0.1",
+                "hast-util-to-html": "^9.0.2",
                 "kleur": "^4.1.5",
                 "rehype-raw": "^7.0.0",
                 "remark-gfm": "^4.0.0",
-                "remark-smartypants": "^3.0.1",
+                "remark-smartypants": "^3.0.2",
                 "source-map": "^0.7.4",
                 "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.1"
+                "vfile": "^6.0.3"
             },
             "engines": {
                 "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
@@ -497,15 +165,15 @@
             }
         },
         "node_modules/@astrojs/vue": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/vue/-/vue-4.2.0.tgz",
-            "integrity": "sha512-cjgPCeZtD2hcqC6vlL1GBdfEQdXcw5nd68IF5NFSiZNdcGpkug1TRgn7QeO2sfjUxI683igy7EwDYvRBXqzZ+A==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/vue/-/vue-4.5.1.tgz",
+            "integrity": "sha512-u9gqaljzsp9jBB9ByUbunCQVJH1Bqx5/r2UQhKTS94l50HvPp7HsXCMiP8kd4juMVIqFduaJfGMrM+KS8jDukA==",
             "dev": true,
             "dependencies": {
-                "@vitejs/plugin-vue": "^5.0.4",
-                "@vitejs/plugin-vue-jsx": "^3.1.0",
-                "@vue/compiler-sfc": "^3.4.27",
-                "vite-plugin-vue-devtools": "^7.1.3"
+                "@vitejs/plugin-vue": "^5.1.3",
+                "@vitejs/plugin-vue-jsx": "^4.0.1",
+                "@vue/compiler-sfc": "^3.5.3",
+                "vite-plugin-vue-devtools": "^7.4.4"
             },
             "engines": {
                 "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
@@ -516,11 +184,11 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
+                "@babel/highlight": "^7.24.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -528,28 +196,28 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-            "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
-            "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.2",
-                "@babel/generator": "^7.24.5",
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-module-transforms": "^7.24.5",
-                "@babel/helpers": "^7.24.5",
-                "@babel/parser": "^7.24.5",
-                "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.5",
-                "@babel/types": "^7.24.5",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -565,11 +233,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+            "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
             "dependencies": {
-                "@babel/types": "^7.24.5",
+                "@babel/types": "^7.25.6",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -579,24 +247,24 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-            "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-            "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+            "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
             "dependencies": {
-                "@babel/compat-data": "^7.23.5",
-                "@babel/helper-validator-option": "^7.23.5",
-                "browserslist": "^4.22.2",
+                "@babel/compat-data": "^7.25.2",
+                "@babel/helper-validator-option": "^7.24.8",
+                "browserslist": "^4.23.1",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -605,19 +273,17 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
-            "integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+            "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-member-expression-to-functions": "^7.24.5",
-                "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.24.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.8",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.25.0",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/traverse": "^7.25.4",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -627,70 +293,40 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-            "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.23.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
-            "integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+            "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.5"
+                "@babel/traverse": "^7.24.8",
+                "@babel/types": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dependencies": {
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
-            "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+            "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-module-imports": "^7.24.3",
-                "@babel/helper-simple-access": "^7.24.5",
-                "@babel/helper-split-export-declaration": "^7.24.5",
-                "@babel/helper-validator-identifier": "^7.24.5"
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/traverse": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -700,34 +336,34 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-            "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+            "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+            "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
-            "integrity": "sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+            "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-member-expression-to-functions": "^7.23.0",
-                "@babel/helper-optimise-call-expression": "^7.22.5"
+                "@babel/helper-member-expression-to-functions": "^7.24.8",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/traverse": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -737,82 +373,72 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
-            "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
             "dependencies": {
-                "@babel/types": "^7.24.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-            "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+            "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
-            "dependencies": {
-                "@babel/types": "^7.24.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-            "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+            "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
-            "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+            "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
             "dependencies": {
-                "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.5",
-                "@babel/types": "^7.24.5"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -822,9 +448,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+            "dependencies": {
+                "@babel/types": "^7.25.6"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -833,14 +462,14 @@
             }
         },
         "node_modules/@babel/plugin-proposal-decorators": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.1.tgz",
-            "integrity": "sha512-zPEvzFijn+hRvJuX2Vu3KbEBN39LN3f7tW3MQO2LsIs57B26KU+kUc82BdAktS1VCM6libzh45eKGI65lg0cpA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.7.tgz",
+            "integrity": "sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
-                "@babel/plugin-syntax-decorators": "^7.24.1"
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-decorators": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -850,12 +479,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-decorators": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.1.tgz",
-            "integrity": "sha512-05RJdO/cCrtVWuAaSn1tS3bH8jbsJa/Y1uD186u6J4C/1mnHFxseeuWpsqr9anvo7TUulev7tm7GDwRV+VuhDw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.7.tgz",
+            "integrity": "sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -865,12 +494,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.1.tgz",
-            "integrity": "sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+            "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -892,11 +521,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-            "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -906,12 +535,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-            "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+            "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -921,15 +550,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.23.4.tgz",
-            "integrity": "sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
+            "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-jsx": "^7.23.3",
-                "@babel/types": "^7.23.4"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/types": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -939,15 +568,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.6.tgz",
-            "integrity": "sha512-6cBG5mBvUu4VUD04OHKnYzbuHNP8huDsD3EDqqpIpsswTDoqHCjLoHb6+QgsV1WsT2nipRqCPgxD3LXnEO7XfA==",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+            "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.23.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-typescript": "^7.23.3"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.25.0",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/plugin-syntax-typescript": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -957,31 +587,28 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+            "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
-            "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+            "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.2",
-                "@babel/generator": "^7.24.5",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.24.5",
-                "@babel/parser": "^7.24.5",
-                "@babel/types": "^7.24.5",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.6",
+                "@babel/parser": "^7.25.6",
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -990,16 +617,31 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
+                "@babel/helper-string-parser": "^7.24.8",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bufbuild/protobuf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.1.0.tgz",
+            "integrity": "sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==",
+            "devOptional": true
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
+            "integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -1464,9 +1106,9 @@
             "dev": true
         },
         "node_modules/@iconify/json": {
-            "version": "2.2.211",
-            "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.211.tgz",
-            "integrity": "sha512-bg/rNpMYwjXJrOR8R56AuMuuNxcSgf/lw/EqtRUyPP1bbiXytF5VJModXohysnsN46M/gr+ydRUjIXRa/vuotA==",
+            "version": "2.2.252",
+            "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.252.tgz",
+            "integrity": "sha512-AtdDjLhN4aBEncnWghiw9JdBRxKAXFcaQmwDFDWPL1UF/cPuuC8BADZzfHIoVcVlEvEbv69tFrzmhj1z/+PGlA==",
             "dev": true,
             "dependencies": {
                 "@iconify/types": "*",
@@ -1480,144 +1122,141 @@
             "dev": true
         },
         "node_modules/@iconify/utils": {
-            "version": "2.1.23",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.23.tgz",
-            "integrity": "sha512-YGNbHKM5tyDvdWZ92y2mIkrfvm5Fvhe6WJSkWu7vvOFhMtYDP0casZpoRz0XEHZCrYsR4stdGT3cZ52yp5qZdQ==",
+            "version": "2.1.33",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
+            "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
             "dev": true,
             "dependencies": {
-                "@antfu/install-pkg": "^0.1.1",
-                "@antfu/utils": "^0.7.7",
+                "@antfu/install-pkg": "^0.4.0",
+                "@antfu/utils": "^0.7.10",
                 "@iconify/types": "^2.0.0",
-                "debug": "^4.3.4",
+                "debug": "^4.3.6",
                 "kolorist": "^1.8.0",
                 "local-pkg": "^0.5.0",
-                "mlly": "^1.6.1"
+                "mlly": "^1.7.1"
             }
         },
-        "node_modules/@iconify/utils/node_modules/@antfu/install-pkg": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.1.1.tgz",
-            "integrity": "sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==",
-            "dev": true,
-            "dependencies": {
-                "execa": "^5.1.1",
-                "find-up": "^5.0.0"
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+            "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/antfu"
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.0.4"
             }
         },
-        "node_modules/@iconify/utils/node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+            "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
             "engines": {
-                "node": ">=10"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.0.4"
             }
         },
-        "node_modules/@iconify/utils/node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+            "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@iconify/utils/node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "node_modules/@iconify/utils/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+            "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@iconify/utils/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@iconify/utils/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@iconify/utils/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+            "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@iconify/utils/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+            "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
         },
-        "node_modules/@iconify/utils/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+            "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
-            "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+            "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
             "cpu": [
                 "x64"
             ],
@@ -1625,20 +1264,29 @@
             "os": [
                 "linux"
             ],
-            "engines": {
-                "glibc": ">=2.26",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
-            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+            "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
-            "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+            "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
             "cpu": [
                 "x64"
             ],
@@ -1646,20 +1294,77 @@
             "os": [
                 "linux"
             ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+            "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
             "engines": {
-                "musl": ">=1.2.2",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.0.5"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+            "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+            "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
-            "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+            "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
             "cpu": [
                 "x64"
             ],
@@ -1668,23 +1373,40 @@
                 "linux"
             ],
             "engines": {
-                "glibc": ">=2.26",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.0.2"
+                "@img/sharp-libvips-linux-x64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+            "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
-            "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+            "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
             "cpu": [
                 "x64"
             ],
@@ -1693,17 +1415,67 @@
                 "linux"
             ],
             "engines": {
-                "musl": ">=1.2.2",
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
-                "npm": ">=9.6.5",
-                "pnpm": ">=7.1.0",
-                "yarn": ">=3.2.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+            "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.2.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+            "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+            "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1720,9 +1492,9 @@
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1736,9 +1508,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
@@ -1747,21 +1519,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@jsdevtools/ez-spawn": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
-            "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
-            "dev": true,
-            "dependencies": {
-                "call-me-maybe": "^1.0.1",
-                "cross-spawn": "^7.0.3",
-                "string-argv": "^0.3.1",
-                "type-detect": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@mdx-js/mdx": {
@@ -1830,17 +1587,21 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oslojs/encoding": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+            "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="
+        },
         "node_modules/@polka/url": {
-            "version": "1.0.0-next.25",
-            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
-            "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
+            "version": "1.0.0-next.28",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+            "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
             "dev": true
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
-            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
-            "dev": true,
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.2.tgz",
+            "integrity": "sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==",
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
@@ -1861,8 +1622,7 @@
         "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.22.4",
@@ -2057,9 +1817,50 @@
             ]
         },
         "node_modules/@shikijs/core": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.5.2.tgz",
-            "integrity": "sha512-wSAOgaz48GmhILFElMCeQypSZmj6Ru6DttOOtl3KNkdJ17ApQuGNCfzpk4cClasVrnIu45++2DBwG4LNMQAfaA=="
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.18.0.tgz",
+            "integrity": "sha512-VK4BNVCd2leY62Nm2JjyxtRLkyrZT/tv104O81eyaCjHq4Adceq2uJVFJJAIof6lT1mBwZrEo2qT/T+grv3MQQ==",
+            "dependencies": {
+                "@shikijs/engine-javascript": "1.18.0",
+                "@shikijs/engine-oniguruma": "1.18.0",
+                "@shikijs/types": "1.18.0",
+                "@shikijs/vscode-textmate": "^9.2.2",
+                "@types/hast": "^3.0.4",
+                "hast-util-to-html": "^9.0.3"
+            }
+        },
+        "node_modules/@shikijs/engine-javascript": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.18.0.tgz",
+            "integrity": "sha512-qoP/aO/ATNwYAUw1YMdaip/YVEstMZEgrwhePm83Ll9OeQPuxDZd48szZR8oSQNQBT8m8UlWxZv8EA3lFuyI5A==",
+            "dependencies": {
+                "@shikijs/types": "1.18.0",
+                "@shikijs/vscode-textmate": "^9.2.2",
+                "oniguruma-to-js": "0.4.3"
+            }
+        },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.18.0.tgz",
+            "integrity": "sha512-B9u0ZKI/cud+TcmF8Chyh+R4V5qQVvyDOqXC2l2a4x73PBSBc6sZ0JRAX3eqyJswqir6ktwApUUGBYePdKnMJg==",
+            "dependencies": {
+                "@shikijs/types": "1.18.0",
+                "@shikijs/vscode-textmate": "^9.2.2"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.18.0.tgz",
+            "integrity": "sha512-O9N36UEaGGrxv1yUrN2nye7gDLG5Uq0/c1LyfmxsvzNPqlHzWo9DI0A4+fhW2y3bGKuQu/fwS7EPdKJJCowcVA==",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^9.2.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
+            "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg=="
         },
         "node_modules/@types/acorn": {
             "version": "4.0.6",
@@ -2133,9 +1934,9 @@
             }
         },
         "node_modules/@types/hast": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
-            "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -2177,9 +1978,9 @@
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
-            "integrity": "sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.4.tgz",
+            "integrity": "sha512-N2XSI2n3sQqp5w7Y/AN/L2XDjBIRGqXko+eDp42sydYSBeJuSm5a1sLf8zakmo8u7tA8NmBgoDLA1HeOESjp9A==",
             "dev": true,
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
@@ -2190,57 +1991,79 @@
             }
         },
         "node_modules/@vitejs/plugin-vue-jsx": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-3.1.0.tgz",
-            "integrity": "sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-4.0.1.tgz",
+            "integrity": "sha512-7mg9HFGnFHMEwCdB6AY83cVK4A6sCqnrjFYF4WIlebYAQVVJ/sC/CiTruVdrRlhrFoeZ8rlMxY9wYpPTIRhhAg==",
             "dev": true,
             "dependencies": {
-                "@babel/core": "^7.23.3",
-                "@babel/plugin-transform-typescript": "^7.23.3",
-                "@vue/babel-plugin-jsx": "^1.1.5"
+                "@babel/core": "^7.24.7",
+                "@babel/plugin-transform-typescript": "^7.24.7",
+                "@vue/babel-plugin-jsx": "^1.2.2"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "peerDependencies": {
-                "vite": "^4.0.0 || ^5.0.0",
+                "vite": "^5.0.0",
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@vue/babel-helper-vue-transform-on": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.1.5.tgz",
-            "integrity": "sha512-SgUymFpMoAyWeYWLAY+MkCK3QEROsiUnfaw5zxOVD/M64KQs8D/4oK6Q5omVA2hnvEOE0SCkH2TZxs/jnnUj7w==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.2.5.tgz",
+            "integrity": "sha512-lOz4t39ZdmU4DJAa2hwPYmKc8EsuGa2U0L9KaZaOJUt0UwQNjNA3AZTq6uEivhOKhhG1Wvy96SvYBoFmCg3uuw==",
             "dev": true
         },
         "node_modules/@vue/babel-plugin-jsx": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.1.5.tgz",
-            "integrity": "sha512-nKs1/Bg9U1n3qSWnsHhCVQtAzI6aQXqua8j/bZrau8ywT1ilXQbK4FwEJGmU8fV7tcpuFvWmmN7TMmV1OBma1g==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.2.5.tgz",
+            "integrity": "sha512-zTrNmOd4939H9KsRIGmmzn3q2zvv1mjxkYZHgqHZgDrXz5B1Q3WyGEjO2f+JrmKghvl1JIRcvo63LgM1kH5zFg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.22.5",
-                "@babel/plugin-syntax-jsx": "^7.22.5",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
-                "@babel/types": "^7.22.5",
-                "@vue/babel-helper-vue-transform-on": "^1.1.5",
-                "camelcase": "^6.3.0",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.6",
+                "@babel/types": "^7.25.6",
+                "@vue/babel-helper-vue-transform-on": "1.2.5",
+                "@vue/babel-plugin-resolve-type": "1.2.5",
                 "html-tags": "^3.3.1",
                 "svg-tags": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vue/babel-plugin-resolve-type": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.2.5.tgz",
+            "integrity": "sha512-U/ibkQrf5sx0XXRnUZD1mo5F7PkpKyTbfXM3a3rC4YnUz6crHEz9Jg09jzzL6QYlXNto/9CePdOg/c87O4Nlfg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.8",
+                "@babel/parser": "^7.25.6",
+                "@vue/compiler-sfc": "^3.5.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-            "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.8.tgz",
+            "integrity": "sha512-Uzlxp91EPjfbpeO5KtC0KnXPkuTfGsNDeaKQJxQN718uz+RqDYarEf7UhQJGK+ZYloD2taUbHTI2J4WrUaZQNA==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.24.4",
-                "@vue/shared": "3.4.27",
+                "@babel/parser": "^7.25.3",
+                "@vue/shared": "3.5.8",
                 "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.0"
@@ -2253,29 +2076,29 @@
             "dev": true
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-            "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.8.tgz",
+            "integrity": "sha512-GUNHWvoDSbSa5ZSHT9SnV5WkStWfzJwwTd6NMGzilOE/HM5j+9EB9zGXdtu/fCNEmctBqMs6C9SvVPpVPuk1Eg==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-core": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-core": "3.5.8",
+                "@vue/shared": "3.5.8"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-            "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.8.tgz",
+            "integrity": "sha512-taYpngQtSysrvO9GULaOSwcG5q821zCoIQBtQQSx7Uf7DxpR6CIHR90toPr9QfDD2mqHQPCSgoWBvJu0yV9zjg==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.24.4",
-                "@vue/compiler-core": "3.4.27",
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/compiler-ssr": "3.4.27",
-                "@vue/shared": "3.4.27",
+                "@babel/parser": "^7.25.3",
+                "@vue/compiler-core": "3.5.8",
+                "@vue/compiler-dom": "3.5.8",
+                "@vue/compiler-ssr": "3.5.8",
+                "@vue/shared": "3.5.8",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.10",
-                "postcss": "^8.4.38",
+                "magic-string": "^0.30.11",
+                "postcss": "^8.4.47",
                 "source-map-js": "^1.2.0"
             }
         },
@@ -2286,107 +2109,110 @@
             "dev": true
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-            "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.8.tgz",
+            "integrity": "sha512-W96PtryNsNG9u0ZnN5Q5j27Z/feGrFV6zy9q5tzJVyJaLiwYxvC0ek4IXClZygyhjm+XKM7WD9pdKi/wIRVC/Q==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-dom": "3.5.8",
+                "@vue/shared": "3.5.8"
             }
         },
         "node_modules/@vue/devtools-core": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.2.0.tgz",
-            "integrity": "sha512-cHSeu70rTtubt2DYia+VDGNTC1m84Xyuk5eNTjmOpMLECaJnWnzCv6kR84EZp7rG+MVZalJG+4ecX2GaTbU3cQ==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-7.4.6.tgz",
+            "integrity": "sha512-7ATNPEbVqThOOAp2bg/YUIm9MqqgimbSk24D05hdXUp89JlXX12aTzdrWd9xZRwS78hDR+wCToHl1C/8sopBrg==",
             "dev": true,
             "dependencies": {
-                "@vue/devtools-kit": "^7.2.0",
-                "@vue/devtools-shared": "^7.2.0",
+                "@vue/devtools-kit": "^7.4.6",
+                "@vue/devtools-shared": "^7.4.6",
                 "mitt": "^3.0.1",
                 "nanoid": "^3.3.4",
                 "pathe": "^1.1.2",
                 "vite-hot-client": "^0.2.3"
-            }
-        },
-        "node_modules/@vue/devtools-kit": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.2.0.tgz",
-            "integrity": "sha512-Kx+U0QiQg/g714euYKfnCdhTcOycSlH1oyTE57D0sAmisdsRCNLfXcnnIwcFY2jdCpuz9DNbuE0VWQuYF5zAZQ==",
-            "dev": true,
-            "dependencies": {
-                "@vue/devtools-shared": "^7.2.0",
-                "hookable": "^5.5.3",
-                "mitt": "^3.0.1",
-                "perfect-debounce": "^1.0.0",
-                "speakingurl": "^14.0.1"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
             }
         },
-        "node_modules/@vue/devtools-shared": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.2.0.tgz",
-            "integrity": "sha512-gVr3IjKjU7axNvclRgICgy1gq/TDnF1hhBAEox+l5mMXZiTIFVIm1zpcIPssc0HxMDgzy+lXqOVsY4DGyZ+ZeA==",
+        "node_modules/@vue/devtools-kit": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.4.6.tgz",
+            "integrity": "sha512-NbYBwPWgEic1AOd9bWExz9weBzFdjiIfov0yRn4DrRfR+EQJCI9dn4I0XS7IxYGdkmUJi8mFW42LLk18WsGqew==",
             "dev": true,
             "dependencies": {
-                "rfdc": "^1.3.1"
+                "@vue/devtools-shared": "^7.4.6",
+                "birpc": "^0.2.17",
+                "hookable": "^5.5.3",
+                "mitt": "^3.0.1",
+                "perfect-debounce": "^1.0.0",
+                "speakingurl": "^14.0.1",
+                "superjson": "^2.2.1"
+            }
+        },
+        "node_modules/@vue/devtools-shared": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.4.6.tgz",
+            "integrity": "sha512-rPeSBzElnHYMB05Cc056BQiJpgocQjY8XVulgni+O9a9Gr9tNXgPteSzFFD+fT/iWMxNuUgGKs9CuW5DZewfIg==",
+            "dev": true,
+            "dependencies": {
+                "rfdc": "^1.4.1"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-            "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.8.tgz",
+            "integrity": "sha512-mlgUyFHLCUZcAYkqvzYnlBRCh0t5ZQfLYit7nukn1GR96gc48Bp4B7OIcSfVSvlG1k3BPfD+p22gi1t2n9tsXg==",
             "dev": true,
             "dependencies": {
-                "@vue/shared": "3.4.27"
+                "@vue/shared": "3.5.8"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-            "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.8.tgz",
+            "integrity": "sha512-fJuPelh64agZ8vKkZgp5iCkPaEqFJsYzxLk9vSC0X3G8ppknclNDr61gDc45yBGTaN5Xqc1qZWU3/NoaBMHcjQ==",
             "dev": true,
             "dependencies": {
-                "@vue/reactivity": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/reactivity": "3.5.8",
+                "@vue/shared": "3.5.8"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-            "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.8.tgz",
+            "integrity": "sha512-DpAUz+PKjTZPUOB6zJgkxVI3GuYc2iWZiNeeHQUw53kdrparSTG6HeXUrYDjaam8dVsCdvQxDz6ZWxnyjccUjQ==",
             "dev": true,
             "dependencies": {
-                "@vue/runtime-core": "3.4.27",
-                "@vue/shared": "3.4.27",
+                "@vue/reactivity": "3.5.8",
+                "@vue/runtime-core": "3.5.8",
+                "@vue/shared": "3.5.8",
                 "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-            "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.8.tgz",
+            "integrity": "sha512-7AmC9/mEeV9mmXNVyUIm1a1AjUhyeeGNbkLh39J00E7iPeGks8OGRB5blJiMmvqSh8SkaS7jkLWSpXtxUCeagA==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-ssr": "3.5.8",
+                "@vue/shared": "3.5.8"
             },
             "peerDependencies": {
-                "vue": "3.4.27"
+                "vue": "3.5.8"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-            "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.8.tgz",
+            "integrity": "sha512-mJleSWbAGySd2RJdX1RBtcrUBX6snyOc0qHpgk3lGi4l9/P/3ny3ELqFWqYdkXIwwNN/kdm8nD9ky8o6l/Lx2A==",
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "version": "8.12.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2485,18 +2311,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/anymatch": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2528,43 +2342,41 @@
             }
         },
         "node_modules/astro": {
-            "version": "4.8.6",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-4.8.6.tgz",
-            "integrity": "sha512-psHIfK+e+bMPhRwghV9yCGH/uc1jvY4DHmDZdoEepax9yA7kzYH0wt3dpkqlcrO2zxl5jzSC3DmqZfkD6wnW9A==",
+            "version": "4.15.9",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-4.15.9.tgz",
+            "integrity": "sha512-51oXq9qrZ5OPWYmEXt1kGrvWmVeWsx28SgBTzi2XW6iwcnW/wC5ONm6ol6qBGSCF93tQvZplXvuzpaw1injECA==",
             "dependencies": {
-                "@astrojs/compiler": "^2.8.0",
-                "@astrojs/internal-helpers": "0.4.0",
-                "@astrojs/markdown-remark": "5.1.0",
+                "@astrojs/compiler": "^2.10.3",
+                "@astrojs/internal-helpers": "0.4.1",
+                "@astrojs/markdown-remark": "5.2.0",
                 "@astrojs/telemetry": "3.1.0",
-                "@babel/core": "^7.24.5",
-                "@babel/generator": "^7.24.5",
-                "@babel/parser": "^7.24.5",
-                "@babel/plugin-transform-react-jsx": "^7.23.4",
-                "@babel/traverse": "^7.24.5",
-                "@babel/types": "^7.24.5",
+                "@babel/core": "^7.25.2",
+                "@babel/plugin-transform-react-jsx": "^7.25.2",
+                "@babel/types": "^7.25.6",
+                "@oslojs/encoding": "^1.0.0",
+                "@rollup/pluginutils": "^5.1.0",
                 "@types/babel__core": "^7.20.5",
                 "@types/cookie": "^0.6.0",
-                "acorn": "^8.11.3",
+                "acorn": "^8.12.1",
                 "aria-query": "^5.3.0",
-                "axobject-query": "^4.0.0",
-                "boxen": "^7.1.1",
-                "chokidar": "^3.6.0",
+                "axobject-query": "^4.1.0",
+                "boxen": "7.1.1",
                 "ci-info": "^4.0.0",
                 "clsx": "^2.1.1",
                 "common-ancestor-path": "^1.0.1",
                 "cookie": "^0.6.0",
                 "cssesc": "^3.0.0",
-                "debug": "^4.3.4",
+                "debug": "^4.3.7",
                 "deterministic-object-hash": "^2.0.2",
                 "devalue": "^5.0.0",
                 "diff": "^5.2.0",
                 "dlv": "^1.1.3",
                 "dset": "^3.1.3",
-                "es-module-lexer": "^1.5.2",
-                "esbuild": "^0.21.2",
+                "es-module-lexer": "^1.5.4",
+                "esbuild": "^0.21.5",
                 "estree-walker": "^3.0.3",
-                "execa": "^8.0.1",
                 "fast-glob": "^3.3.2",
+                "fastq": "^1.17.1",
                 "flattie": "^1.1.1",
                 "github-slugger": "^2.0.0",
                 "gray-matter": "^4.0.3",
@@ -2572,29 +2384,33 @@
                 "http-cache-semantics": "^4.1.1",
                 "js-yaml": "^4.1.0",
                 "kleur": "^4.1.5",
-                "magic-string": "^0.30.10",
+                "magic-string": "^0.30.11",
+                "magicast": "^0.3.5",
+                "micromatch": "^4.0.8",
                 "mrmime": "^2.0.0",
-                "ora": "^8.0.1",
-                "p-limit": "^5.0.0",
+                "neotraverse": "^0.6.18",
+                "ora": "^8.1.0",
+                "p-limit": "^6.1.0",
                 "p-queue": "^8.0.1",
-                "path-to-regexp": "^6.2.2",
-                "preferred-pm": "^3.1.3",
+                "preferred-pm": "^4.0.0",
                 "prompts": "^2.4.2",
                 "rehype": "^13.0.1",
-                "resolve": "^1.22.8",
-                "semver": "^7.6.2",
-                "shiki": "^1.5.1",
-                "string-width": "^7.1.0",
+                "semver": "^7.6.3",
+                "shiki": "^1.16.2",
+                "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0",
-                "tsconfck": "^3.0.3",
+                "tinyexec": "^0.3.0",
+                "tsconfck": "^3.1.3",
                 "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.1",
-                "vite": "^5.2.11",
-                "vitefu": "^0.2.5",
-                "which-pm": "^2.1.1",
+                "vfile": "^6.0.3",
+                "vite": "^5.4.3",
+                "vitefu": "^1.0.2",
+                "which-pm": "^3.0.0",
+                "xxhash-wasm": "^1.0.2",
                 "yargs-parser": "^21.1.1",
                 "zod": "^3.23.8",
-                "zod-to-json-schema": "^3.23.0"
+                "zod-to-json-schema": "^3.23.2",
+                "zod-to-ts": "^1.2.0"
             },
             "bin": {
                 "astro": "astro.js"
@@ -2609,9 +2425,9 @@
             }
         },
         "node_modules/astro/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2620,11 +2436,11 @@
             }
         },
         "node_modules/axobject-query": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
-            "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
-            "dependencies": {
-                "dequal": "^2.0.3"
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/bail": {
@@ -2647,12 +2463,13 @@
             "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
             "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
         },
-        "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "engines": {
-                "node": ">=8"
+        "node_modules/birpc": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.17.tgz",
+            "integrity": "sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/boolbase": {
@@ -2747,9 +2564,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.22.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-            "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+            "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2765,10 +2582,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001565",
-                "electron-to-chromium": "^1.4.601",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "caniuse-lite": "^1.0.30001663",
+                "electron-to-chromium": "^1.5.28",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2776,6 +2593,12 @@
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
+        },
+        "node_modules/buffer-builder": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+            "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+            "devOptional": true
         },
         "node_modules/bufferutil": {
             "version": "4.0.8",
@@ -2804,12 +2627,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/call-me-maybe": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-            "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-            "dev": true
-        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2819,22 +2636,10 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001572",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
-            "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
+            "version": "1.0.30001663",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+            "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2909,26 +2714,19 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+            "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^4.0.1"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 14.16.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/ci-info": {
@@ -2957,14 +2755,14 @@
             }
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3048,6 +2846,12 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "node_modules/colorjs.io": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+            "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+            "devOptional": true
+        },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3087,10 +2891,26 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/copy-anything": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+            "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+            "dev": true,
+            "dependencies": {
+                "is-what": "^4.1.8"
+            },
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -3118,16 +2938,16 @@
             "dev": true
         },
         "node_modules/dayjs": {
-            "version": "1.11.11",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-            "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -3279,14 +3099,14 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.616",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-            "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg=="
+            "version": "1.5.28",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.28.tgz",
+            "integrity": "sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw=="
         },
         "node_modules/emoji-regex": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-            "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -3300,18 +3120,18 @@
             }
         },
         "node_modules/error-stack-parser-es": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-0.1.4.tgz",
-            "integrity": "sha512-l0uy0kAoo6toCgVOYaAayqtPa2a1L15efxUMEnQebKwLQX2X0OpS6wMMQdc4juJXmxd9i40DuaUHq+mjIya9TQ==",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-0.1.5.tgz",
+            "integrity": "sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-            "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg=="
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+            "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
         },
         "node_modules/esbuild": {
             "version": "0.21.5",
@@ -3351,9 +3171,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "engines": {
                 "node": ">=6"
             }
@@ -3434,9 +3254,9 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "9.26.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.26.0.tgz",
-            "integrity": "sha512-eTvlxXgd4ijE1cdur850G6KalZqk65k1JKoOI2d1kT3hr8sPD07j1q98FRFdNnpxBELGPWxZmInxeHGF/GxtqQ==",
+            "version": "9.28.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.28.0.tgz",
+            "integrity": "sha512-ShrihdjIhOTxs+MfWun6oJWuk+g/LAhN+CiuOl/jjkG3l0F2AuK5NMTaWqyvBgkFtpYmyks6P4603mLmhNJW8g==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
@@ -3444,8 +3264,8 @@
                 "natural-compare": "^1.4.0",
                 "nth-check": "^2.1.1",
                 "postcss-selector-parser": "^6.0.15",
-                "semver": "^7.6.0",
-                "vue-eslint-parser": "^9.4.2",
+                "semver": "^7.6.3",
+                "vue-eslint-parser": "^9.4.3",
                 "xml-name-validator": "^4.0.0"
             },
             "engines": {
@@ -3471,9 +3291,9 @@
             }
         },
         "node_modules/eslint-plugin-vue/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -3815,6 +3635,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
             "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^8.0.1",
@@ -3831,6 +3652,21 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/extend": {
@@ -3883,9 +3719,9 @@
             "dev": true
         },
         "node_modules/fastq": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-            "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -3917,12 +3753,24 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-up-simple": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+            "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3998,14 +3846,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4029,6 +3869,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
             "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
             "engines": {
                 "node": ">=16"
             },
@@ -4131,17 +3972,6 @@
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/hast-util-from-html": {
@@ -4268,15 +4098,14 @@
             }
         },
         "node_modules/hast-util-to-html": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.1.tgz",
-            "integrity": "sha512-hZOofyZANbyWo+9RP75xIDV/gq+OUKx+T46IlwERnKmfpwp81XBFbT9mi26ws+SJchA4RVUQwIBJpqEOBhMzEQ==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
+            "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
                 "ccount": "^2.0.0",
                 "comma-separated-tokens": "^2.0.0",
-                "hast-util-raw": "^9.0.0",
                 "hast-util-whitespace": "^3.0.0",
                 "html-void-elements": "^3.0.0",
                 "mdast-util-to-hast": "^13.0.0",
@@ -4443,6 +4272,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
             "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
             "engines": {
                 "node": ">=16.17.0"
             }
@@ -4457,9 +4287,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
             "devOptional": true
         },
         "node_modules/import-fresh": {
@@ -4543,50 +4373,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
             "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-            "dependencies": {
-                "hasown": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-decimal": {
             "version": "2.0.1",
@@ -4723,6 +4509,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -4731,14 +4518,26 @@
             }
         },
         "node_modules/is-unicode-supported": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-            "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "engines": {
                 "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "4.1.16",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+            "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
             }
         },
         "node_modules/is-wsl": {
@@ -4758,7 +4557,8 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -4926,6 +4726,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -5003,11 +4804,21 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.10",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "version": "0.30.11",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+            "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+            "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+            "dependencies": {
+                "@babel/parser": "^7.25.4",
+                "@babel/types": "^7.25.4",
+                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/markdown-extensions": {
@@ -5352,7 +5163,8 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -6078,8 +5890,20 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6104,14 +5928,14 @@
             "dev": true
         },
         "node_modules/mlly": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.0.tgz",
-            "integrity": "sha512-U9SDaXGEREBYQgfejV97coK0UL1r+qnF2SyO9A3qcI8MzKnsIFKHNVEkrDyNncQTKQQumsasmeq84eNMdBfsNQ==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
+            "integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.11.3",
                 "pathe": "^1.1.2",
-                "pkg-types": "^1.1.0",
+                "pkg-types": "^1.1.1",
                 "ufo": "^1.5.3"
             }
         },
@@ -6124,9 +5948,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
@@ -6151,6 +5975,14 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
+        "node_modules/neotraverse": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/nlcst-to-string": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
@@ -6174,22 +6006,15 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
-        },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
         },
         "node_modules/npm-run-path": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-            "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^4.0.0"
             },
@@ -6204,6 +6029,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6233,17 +6059,28 @@
             }
         },
         "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dependencies": {
-                "mimic-fn": "^4.0.0"
+                "mimic-function": "^5.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/oniguruma-to-js": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
+            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
+            "dependencies": {
+                "regex": "^4.3.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/open": {
@@ -6282,18 +6119,18 @@
             }
         },
         "node_modules/ora": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
-            "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.0.tgz",
+            "integrity": "sha512-GQEkNkH/GHOhPFXcqZs3IDahXEQcQxsSjEkK4KvEEST4t7eNzoMjxTzef+EZ+JluDEV+Raoi3WQ2CflnRdSVnQ==",
             "dependencies": {
                 "chalk": "^5.3.0",
-                "cli-cursor": "^4.0.0",
+                "cli-cursor": "^5.0.0",
                 "cli-spinners": "^2.9.2",
                 "is-interactive": "^2.0.0",
                 "is-unicode-supported": "^2.0.0",
                 "log-symbols": "^6.0.0",
-                "stdin-discarder": "^0.2.1",
-                "string-width": "^7.0.0",
+                "stdin-discarder": "^0.2.2",
+                "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0"
             },
             "engines": {
@@ -6315,11 +6152,11 @@
             }
         },
         "node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
+            "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
             "dependencies": {
-                "yocto-queue": "^1.0.0"
+                "yocto-queue": "^1.1.1"
             },
             "engines": {
                 "node": ">=18"
@@ -6332,6 +6169,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6346,6 +6184,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -6360,6 +6199,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6400,6 +6240,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/package-manager-detector": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.0.tgz",
+            "integrity": "sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==",
+            "dev": true
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -6486,19 +6332,10 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-        },
-        "node_modules/path-to-regexp": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
         },
         "node_modules/pathe": {
             "version": "1.1.2",
@@ -6606,13 +6443,13 @@
             }
         },
         "node_modules/pkg-types": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.1.tgz",
-            "integrity": "sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
+            "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
             "dev": true,
             "dependencies": {
                 "confbox": "^0.1.7",
-                "mlly": "^1.7.0",
+                "mlly": "^1.7.1",
                 "pathe": "^1.1.2"
             }
         },
@@ -6657,29 +6494,16 @@
             }
         },
         "node_modules/preferred-pm": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.3.tgz",
-            "integrity": "sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.0.0.tgz",
+            "integrity": "sha512-gYBeFTZLu055D8Vv3cSPox/0iTPtkzxpLroSYYA7WXgRi31WCJ51Uyl8ZiPeUUjyvs2MBzK+S8v9JVUgHU/Sqw==",
             "dependencies": {
-                "find-up": "^5.0.0",
+                "find-up-simple": "^1.0.0",
                 "find-yarn-workspace-root2": "1.2.16",
-                "path-exists": "^4.0.0",
-                "which-pm": "2.0.0"
+                "which-pm": "^3.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/preferred-pm/node_modules/which-pm": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.0.0.tgz",
-            "integrity": "sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==",
-            "dependencies": {
-                "load-yaml-file": "^0.2.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8.15"
+                "node": ">=18.12"
             }
         },
         "node_modules/prelude-ls": {
@@ -6692,9 +6516,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -6707,24 +6531,18 @@
             }
         },
         "node_modules/prettier-plugin-astro": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.13.0.tgz",
-            "integrity": "sha512-5HrJNnPmZqTUNoA97zn4gNQv9BgVhv+et03314WpQ9H9N8m2L9OSV798olwmG2YLXPl1iSstlJCR1zB3x5xG4g==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+            "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
             "dev": true,
             "dependencies": {
-                "@astrojs/compiler": "^1.5.5",
+                "@astrojs/compiler": "^2.9.1",
                 "prettier": "^3.0.0",
                 "sass-formatter": "^0.7.6"
             },
             "engines": {
                 "node": "^14.15.0 || >=16.0.0"
             }
-        },
-        "node_modules/prettier-plugin-astro/node_modules/@astrojs/compiler": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.8.2.tgz",
-            "integrity": "sha512-o/ObKgtMzl8SlpIdzaxFnt7SATKPxu4oIP/1NL+HDJRzxfJcAkOTAb/ZKMRyULbz4q+1t2/DAebs2Z1QairkZw==",
-            "dev": true
         },
         "node_modules/prismjs": {
             "version": "1.29.0",
@@ -6792,15 +6610,23 @@
             ]
         },
         "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+            "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+            "optional": true,
+            "peer": true,
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
+        },
+        "node_modules/regex": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.2.tgz",
+            "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw=="
         },
         "node_modules/rehype": {
             "version": "13.0.1",
@@ -6969,9 +6795,9 @@
             }
         },
         "node_modules/remark-smartypants": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.1.tgz",
-            "integrity": "sha512-qyshfCl2eLO0i0558e79ZJsfojC5wjnYLByjt0FmjJQN6aYwcRxpoj784LZJSoWCdnA2ubh5rLNGb8Uur/wDng==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+            "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
             "dependencies": {
                 "retext": "^9.0.0",
                 "retext-smartypants": "^6.0.0",
@@ -6996,22 +6822,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7022,46 +6832,19 @@
             }
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/restore-cursor/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/retext": {
             "version": "9.0.0",
@@ -7093,9 +6876,9 @@
             }
         },
         "node_modules/retext-smartypants": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.1.0.tgz",
-            "integrity": "sha512-LDPXg95346bqFZnDMHo0S7Rq5p64+B+N8Vz733+wPMDtwb9rCOs9LIdIEhrUOU+TAywX9St+ocQWJt8wrzivcQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.1.1.tgz",
+            "integrity": "sha512-onsHf34i/GzgElJgtT1K2V+31yEhWs7NJboKNxXJcmVMMPxLpgxZ9iADoMdydd6j/bHic5F/aNq0CGqElEtu2g==",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
                 "nlcst-to-string": "^4.0.0",
@@ -7130,9 +6913,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "node_modules/rimraf": {
@@ -7218,6 +7001,15 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/rxjs": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "devOptional": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
         "node_modules/s.color": {
             "version": "0.0.15",
             "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
@@ -7225,12 +7017,13 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.77.2",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
-            "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
-            "devOptional": true,
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.3.tgz",
+            "integrity": "sha512-m7dZxh0W9EZ3cw50Me5GOuYm/tVAJAn91SUnohLRo9cXBixGUOdvmryN+dXpwR831bhoY3Zv7rEFt85PUwTmzA==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
-                "chokidar": ">=3.0.0 <4.0.0",
+                "chokidar": "^4.0.0",
                 "immutable": "^4.0.0",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
@@ -7239,6 +7032,393 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.79.3.tgz",
+            "integrity": "sha512-zUve2qCn6uSOMZnZazLzrDWq//OQWFle5G45vJjv3B/ADIA3TXVgqHqN3u7D2vGajOGREz0HN5nhliSoKmQqZA==",
+            "devOptional": true,
+            "dependencies": {
+                "@bufbuild/protobuf": "^2.0.0",
+                "buffer-builder": "^0.2.0",
+                "colorjs.io": "^0.5.0",
+                "immutable": "^4.0.0",
+                "rxjs": "^7.4.0",
+                "supports-color": "^8.1.1",
+                "varint": "^6.0.0"
+            },
+            "bin": {
+                "sass": "dist/bin/sass.js"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "optionalDependencies": {
+                "sass-embedded-android-arm": "1.79.3",
+                "sass-embedded-android-arm64": "1.79.3",
+                "sass-embedded-android-ia32": "1.79.3",
+                "sass-embedded-android-riscv64": "1.79.3",
+                "sass-embedded-android-x64": "1.79.3",
+                "sass-embedded-darwin-arm64": "1.79.3",
+                "sass-embedded-darwin-x64": "1.79.3",
+                "sass-embedded-linux-arm": "1.79.3",
+                "sass-embedded-linux-arm64": "1.79.3",
+                "sass-embedded-linux-ia32": "1.79.3",
+                "sass-embedded-linux-musl-arm": "1.79.3",
+                "sass-embedded-linux-musl-arm64": "1.79.3",
+                "sass-embedded-linux-musl-ia32": "1.79.3",
+                "sass-embedded-linux-musl-riscv64": "1.79.3",
+                "sass-embedded-linux-musl-x64": "1.79.3",
+                "sass-embedded-linux-riscv64": "1.79.3",
+                "sass-embedded-linux-x64": "1.79.3",
+                "sass-embedded-win32-arm64": "1.79.3",
+                "sass-embedded-win32-ia32": "1.79.3",
+                "sass-embedded-win32-x64": "1.79.3"
+            }
+        },
+        "node_modules/sass-embedded-android-arm": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.79.3.tgz",
+            "integrity": "sha512-rrdaVDkKBLUqzdqlBFamUbeuLG+8r/QLXHIgz4qPhIDqceJH6ds0Vzrae9Ef6DhYfMatOg2xiScdatwQ8Yl/hA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-arm64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.79.3.tgz",
+            "integrity": "sha512-Wqm/WKHIDQl7w7eIQRO/GQ7EXfnwNpipCyJL7Xtb15vSAV64J4/0D/esy6GOPlVG+qcu8/XN8NV7Bf5wZ2ExUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-ia32": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.79.3.tgz",
+            "integrity": "sha512-6rDmH0O7hjBP04/xBAFzSYYMU/7MrQYCak4541BZIbIfa2uw0x/8+mB7lZjdgFsBrFjcpdVCPhZPUE6Y50c00A==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-riscv64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.79.3.tgz",
+            "integrity": "sha512-B/PgB0AfTCvOlF1g89raJTwTXIUQUM3OXDWqEKIlJEZM1Yao91i8ZkyrFkDMzT4G5sETy4o8pgK+qE9+7bFlug==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-android-x64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.79.3.tgz",
+            "integrity": "sha512-a5cpo9Yw4xnX32Uo3WfMZLaTVnI/h2n7U3K3eTygyj707yhGkUB0i+qxldzCw8MmKivIu9irG6O4kmnRjW6f7g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-darwin-arm64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.79.3.tgz",
+            "integrity": "sha512-imafD0nlVz5FJhqBqxUbG5rK4E3cu1GxhMZ5VhKm0k4t5jFQo+3OjN7sHT4Ee2Mk1g8sjr5dtq5enDU4fs6lXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-darwin-x64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.79.3.tgz",
+            "integrity": "sha512-pjciT1FcMUMA4rWdpyZYSwMOvxk5JP7R6vy7TzvqkUEqXxP9FTflYnAiwgYUDVTpngHHqRxTjdyW+e+h2L9dHw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.79.3.tgz",
+            "integrity": "sha512-n0bDtzABPE5YaL9wSLxNPiQMl1zArsGblHJyED6fEHz41m+OkCTopfO8IVjcf+MBrK/j11gonxiIGWO+fNOxvg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-arm64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.79.3.tgz",
+            "integrity": "sha512-ODo8ghwk6KHxchgwxq4CwgfYwWdreEbsQoukeEgRKxHcuLB9XF6tol9pGlfrc8sYox48Vp5WDCZuzgoo6rJ6tg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-ia32": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.79.3.tgz",
+            "integrity": "sha512-oC3rUyIE6mEm2etsc4CuNu6IVmB6CoSM4KsubxzCD3S37QFXq8wYbI0t9iiDdTkKb5Iu+vUyhn+tYJRVHg0tvw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.79.3.tgz",
+            "integrity": "sha512-TOUYMtDs9xoMsJSEEr7NjtcVCqVpg1eSOQHXXruJ1kiYfxwmHrCYTjTLoefbZ29mWqIq8NUaXJG4rZNDK6NzRA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-arm64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.79.3.tgz",
+            "integrity": "sha512-Q9/5lsrK/JnQci3DwxZ9PGIIrRxuo/bySv+gbyVp8Kb7gdkZcEsY7HkxaBJfwVEwpZSGAyCviyZDHDMILjliOw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-ia32": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.79.3.tgz",
+            "integrity": "sha512-T2uERh3gs9eWUzdkDadPuYbelQJQLZyX8myutUd4fxyrQ7ToQRBwcMoynEjl48DBHnM0oRiJUHrV9uFuJ+fmRA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-riscv64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.79.3.tgz",
+            "integrity": "sha512-XTuYtTBPFeEjydS2GsIUkMztzXIiz13noknE7m1yAbVxOchu9jD9FCLAdK9pVPPki+9BiLSxsutYwOcQn8atqQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-musl-x64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.79.3.tgz",
+            "integrity": "sha512-gDHfaPlxT/XQTMbfb2y+U6zDMuI8pfapVXTYlUrgYhKH2KoICclIvahhjFii5i5+1dHpfGzjgYKBqI3nvZsYFg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-riscv64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.79.3.tgz",
+            "integrity": "sha512-NONTa//1ZfxA87+Zjp3rabL+Z9gM67FJBdktRKXXMBAce5i8eCj/eqJGUOGPjYxtvxtQw77cex0qMr9SZnX6ww==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-linux-x64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.79.3.tgz",
+            "integrity": "sha512-drlUqMMw222+f/T5sNrIAv+z0vQwLkO4zAlDmf4biLdWIloPP/3plTodAkMyfagNcvA8jG2jN414pJXBI3zK6w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-arm64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.79.3.tgz",
+            "integrity": "sha512-gYz0IUb0fLkHUbhq+HR52wvQfG75Zu1s48/v48TqC+b04H/01k2eiawp/Ec1f+lhpIL/pr5+n5jWR6CjkxPdnQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-ia32": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.79.3.tgz",
+            "integrity": "sha512-fbDTyzbqRc+xCWZ+YHSDt2WvGk5PW2K0SjyHuwes/Fls1+wdO4iHIukE/pD+HSWytYrtCqhe7EFq5Ug5HxGTLg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded-win32-x64": {
+            "version": "1.79.3",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.79.3.tgz",
+            "integrity": "sha512-vvfr6wyCaHvdQbGS8UkYab6DXc1FKJRYFT5aFE3QTVqbzCqmJ5tf80E4+gvB99nljLtMjwKR1d332iWI9KDLhw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/sass-embedded/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sass-embedded/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "devOptional": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/sass-formatter": {
@@ -7271,48 +7451,47 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.33.4",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
-            "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
+            "version": "0.33.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+            "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
             "hasInstallScript": true,
             "dependencies": {
                 "color": "^4.2.3",
                 "detect-libc": "^2.0.3",
-                "semver": "^7.6.0"
+                "semver": "^7.6.3"
             },
             "engines": {
-                "libvips": ">=8.15.2",
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.33.4",
-                "@img/sharp-darwin-x64": "0.33.4",
-                "@img/sharp-libvips-darwin-arm64": "1.0.2",
-                "@img/sharp-libvips-darwin-x64": "1.0.2",
-                "@img/sharp-libvips-linux-arm": "1.0.2",
-                "@img/sharp-libvips-linux-arm64": "1.0.2",
-                "@img/sharp-libvips-linux-s390x": "1.0.2",
-                "@img/sharp-libvips-linux-x64": "1.0.2",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
-                "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
-                "@img/sharp-linux-arm": "0.33.4",
-                "@img/sharp-linux-arm64": "0.33.4",
-                "@img/sharp-linux-s390x": "0.33.4",
-                "@img/sharp-linux-x64": "0.33.4",
-                "@img/sharp-linuxmusl-arm64": "0.33.4",
-                "@img/sharp-linuxmusl-x64": "0.33.4",
-                "@img/sharp-wasm32": "0.33.4",
-                "@img/sharp-win32-ia32": "0.33.4",
-                "@img/sharp-win32-x64": "0.33.4"
+                "@img/sharp-darwin-arm64": "0.33.5",
+                "@img/sharp-darwin-x64": "0.33.5",
+                "@img/sharp-libvips-darwin-arm64": "1.0.4",
+                "@img/sharp-libvips-darwin-x64": "1.0.4",
+                "@img/sharp-libvips-linux-arm": "1.0.5",
+                "@img/sharp-libvips-linux-arm64": "1.0.4",
+                "@img/sharp-libvips-linux-s390x": "1.0.4",
+                "@img/sharp-libvips-linux-x64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+                "@img/sharp-linux-arm": "0.33.5",
+                "@img/sharp-linux-arm64": "0.33.5",
+                "@img/sharp-linux-s390x": "0.33.5",
+                "@img/sharp-linux-x64": "0.33.5",
+                "@img/sharp-linuxmusl-arm64": "0.33.5",
+                "@img/sharp-linuxmusl-x64": "0.33.5",
+                "@img/sharp-wasm32": "0.33.5",
+                "@img/sharp-win32-ia32": "0.33.5",
+                "@img/sharp-win32-x64": "0.33.5"
             }
         },
         "node_modules/sharp/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -7324,6 +7503,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -7335,16 +7515,22 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/shiki": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.5.2.tgz",
-            "integrity": "sha512-fpPbuSaatinmdGijE7VYUD3hxLozR3ZZ+iAx8Iy2X6REmJGyF5hQl94SgmiUNTospq346nXUVZx0035dyGvIVw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.18.0.tgz",
+            "integrity": "sha512-8jo7tOXr96h9PBQmOHVrltnETn1honZZY76YA79MHheGQg55jBvbm9dtU+MI5pjC5NJCFuA6rvVTLVeSW5cE4A==",
             "dependencies": {
-                "@shikijs/core": "1.5.2"
+                "@shikijs/core": "1.18.0",
+                "@shikijs/engine-javascript": "1.18.0",
+                "@shikijs/engine-oniguruma": "1.18.0",
+                "@shikijs/types": "1.18.0",
+                "@shikijs/vscode-textmate": "^9.2.2",
+                "@types/hast": "^3.0.4"
             }
         },
         "node_modules/signal-exit": {
@@ -7435,19 +7621,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/string-argv": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6.19"
-            }
-        },
         "node_modules/string-width": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-            "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -7507,6 +7684,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7543,6 +7721,18 @@
                 "s.color": "0.0.15"
             }
         },
+        "node_modules/superjson": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+            "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+            "dev": true,
+            "dependencies": {
+                "copy-anything": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7552,17 +7742,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/svg-tags": {
@@ -7576,6 +7755,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
+            "integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg=="
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -7624,9 +7808,9 @@
             }
         },
         "node_modules/tsconfck": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.3.tgz",
-            "integrity": "sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.3.tgz",
+            "integrity": "sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==",
             "bin": {
                 "tsconfck": "bin/tsconfck.js"
             },
@@ -7642,6 +7826,12 @@
                 }
             }
         },
+        "node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "devOptional": true
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7652,15 +7842,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/type-fest": {
@@ -7674,25 +7855,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ufo": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
-            "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
-            "dev": true
-        },
-        "node_modules/unherit": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.1.tgz",
-            "integrity": "sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
+        "node_modules/typescript": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
+        "node_modules/ufo": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+            "dev": true
+        },
         "node_modules/unified": {
-            "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
-            "integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "bail": "^2.0.0",
@@ -7843,33 +8028,39 @@
             }
         },
         "node_modules/unplugin": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.10.1.tgz",
-            "integrity": "sha512-d6Mhq8RJeGA8UfKCu54Um4lFA0eSaRa3XxdAJg8tIdxbu1ubW0hBCZUL7yI2uGyYCRndvbK8FLHzqy2XKfeMsg==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.14.1.tgz",
+            "integrity": "sha512-lBlHbfSFPToDYp9pjXlUEFVxYLaue9f9T1HC+4OHlmj+HnMDdz9oZY+erXfoCe/5V/7gKUSY2jpXPb9S7f0f/w==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.11.3",
-                "chokidar": "^3.6.0",
-                "webpack-sources": "^3.2.3",
-                "webpack-virtual-modules": "^0.6.1"
+                "acorn": "^8.12.1",
+                "webpack-virtual-modules": "^0.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "webpack-sources": "^3"
+            },
+            "peerDependenciesMeta": {
+                "webpack-sources": {
+                    "optional": true
+                }
             }
         },
         "node_modules/unplugin-icons": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/unplugin-icons/-/unplugin-icons-0.19.0.tgz",
-            "integrity": "sha512-u5g/gIZPZEj1wUGEQxe9nzftOSqmblhusc+sL3cawIRoIt/xWpE6XYcPOfAeFTYNjSbRrX/3QiX89PFiazgU1w==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/unplugin-icons/-/unplugin-icons-0.19.3.tgz",
+            "integrity": "sha512-EUegRmsAI6+rrYr0vXjFlIP+lg4fSC4zb62zAZKx8FGXlWAGgEGBCa3JDe27aRAXhistObLPbBPhwa/0jYLFkQ==",
             "dev": true,
             "dependencies": {
-                "@antfu/install-pkg": "^0.3.3",
-                "@antfu/utils": "^0.7.7",
-                "@iconify/utils": "^2.1.23",
-                "debug": "^4.3.4",
+                "@antfu/install-pkg": "^0.4.1",
+                "@antfu/utils": "^0.7.10",
+                "@iconify/utils": "^2.1.29",
+                "debug": "^4.3.6",
                 "kolorist": "^1.8.0",
                 "local-pkg": "^0.5.0",
-                "unplugin": "^1.10.1"
+                "unplugin": "^1.12.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -7900,9 +8091,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7918,8 +8109,8 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -7943,13 +8134,18 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
+        "node_modules/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+            "devOptional": true
+        },
         "node_modules/vfile": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
-            "integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
             "dependencies": {
                 "@types/unist": "^3.0.0",
-                "unist-util-stringify-position": "^4.0.0",
                 "vfile-message": "^4.0.0"
             },
             "funding": {
@@ -7984,9 +8180,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-            "integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+            "version": "5.4.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+            "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -8054,19 +8250,19 @@
             }
         },
         "node_modules/vite-plugin-inspect": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.8.4.tgz",
-            "integrity": "sha512-G0N3rjfw+AiiwnGw50KlObIHYWfulVwaCBUBLh2xTW9G1eM9ocE5olXkEYUbwyTmX+azM8duubi+9w5awdCz+g==",
+            "version": "0.8.7",
+            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.8.7.tgz",
+            "integrity": "sha512-/XXou3MVc13A5O9/2Nd6xczjrUwt7ZyI9h8pTnUMkr5SshLcb0PJUOVq2V+XVkdeU4njsqAtmK87THZuO2coGA==",
             "dev": true,
             "dependencies": {
-                "@antfu/utils": "^0.7.7",
+                "@antfu/utils": "^0.7.10",
                 "@rollup/pluginutils": "^5.1.0",
-                "debug": "^4.3.4",
-                "error-stack-parser-es": "^0.1.1",
+                "debug": "^4.3.6",
+                "error-stack-parser-es": "^0.1.5",
                 "fs-extra": "^11.2.0",
                 "open": "^10.1.0",
                 "perfect-debounce": "^1.0.0",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "sirv": "^2.0.4"
             },
             "engines": {
@@ -8085,18 +8281,18 @@
             }
         },
         "node_modules/vite-plugin-vue-devtools": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-7.2.0.tgz",
-            "integrity": "sha512-bFWwx/YF9M+aXTjDo0/6DrC7+WCzLg7wAmFoQA3Gd7cv5WV4u65hHSZN8bq0zhgHqtYQZdWnp0L2z6JNCwcIGg==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-7.4.6.tgz",
+            "integrity": "sha512-lOKur3qovCB3BQStL0qfHEoIusqya1ngfxfWuqn9DTa6h9rlw6+S3PV4geOP5YBGYQ4NW1hRX70OD8I+sYr1dA==",
             "dev": true,
             "dependencies": {
-                "@vue/devtools-core": "^7.2.0",
-                "@vue/devtools-kit": "^7.2.0",
-                "@vue/devtools-shared": "^7.2.0",
+                "@vue/devtools-core": "^7.4.6",
+                "@vue/devtools-kit": "^7.4.6",
+                "@vue/devtools-shared": "^7.4.6",
                 "execa": "^8.0.1",
                 "sirv": "^2.0.4",
-                "vite-plugin-inspect": "^0.8.4",
-                "vite-plugin-vue-inspector": "^5.1.0"
+                "vite-plugin-inspect": "^0.8.7",
+                "vite-plugin-vue-inspector": "^5.2.0"
             },
             "engines": {
                 "node": ">=v14.21.3"
@@ -8106,9 +8302,9 @@
             }
         },
         "node_modules/vite-plugin-vue-inspector": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-inspector/-/vite-plugin-vue-inspector-5.1.0.tgz",
-            "integrity": "sha512-yIw9dvBz9nQW7DPfbJtUVW6JTnt67hqTPRnTwT2CZWMqDvISyQHRjgKl32nlMh1DRH+92533Sv6t59pWMLUCWA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-inspector/-/vite-plugin-vue-inspector-5.2.0.tgz",
+            "integrity": "sha512-wWxyb9XAtaIvV/Lr7cqB1HIzmHZFVUJsTNm3yAxkS87dgh/Ky4qr2wDEWNxF23fdhVa3jQ8MZREpr4XyiuaRqA==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.23.0",
@@ -8126,9 +8322,13 @@
             }
         },
         "node_modules/vitefu": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
-            "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.2.tgz",
+            "integrity": "sha512-0/iAvbXyM3RiPPJ4lyD4w6Mjgtf4ejTK6TPvTNG3H32PLwuT0N/ZjJLiXug7ETE/LWtTeHw9WRv7uX/tIKYyKg==",
+            "workspaces": [
+                "tests/deps/*",
+                "tests/projects/*"
+            ],
             "peerDependencies": {
                 "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
             },
@@ -8139,16 +8339,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-            "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.8.tgz",
+            "integrity": "sha512-hvuvuCy51nP/1fSRvrrIqTLSvrSyz2Pq+KQ8S8SXCxTWVE0nMaOnSDnSOxV1eYmGfvK7mqiwvd1C59CEEz7dAQ==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/compiler-sfc": "3.4.27",
-                "@vue/runtime-dom": "3.4.27",
-                "@vue/server-renderer": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-dom": "3.5.8",
+                "@vue/compiler-sfc": "3.5.8",
+                "@vue/runtime-dom": "3.5.8",
+                "@vue/server-renderer": "3.5.8",
+                "@vue/shared": "3.5.8"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -8160,9 +8360,9 @@
             }
         },
         "node_modules/vue-eslint-parser": {
-            "version": "9.4.2",
-            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
-            "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
+            "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4",
@@ -8184,9 +8384,9 @@
             }
         },
         "node_modules/vue-eslint-parser/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -8204,25 +8404,17 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/webpack-virtual-modules": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.1.tgz",
-            "integrity": "sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+            "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "dev": true
         },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -8234,15 +8426,14 @@
             }
         },
         "node_modules/which-pm": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.1.1.tgz",
-            "integrity": "sha512-xzzxNw2wMaoCWXiGE8IJ9wuPMU+EYhFksjHxrRT8kMT5SnocBPRg69YAMtyV4D12fP582RA+k3P8H9J5EMdIxQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-3.0.0.tgz",
+            "integrity": "sha512-ysVYmw6+ZBhx3+ZkcPwRuJi38ZOTLJJ33PSHaitLxSKUMsh0LkKd0nC69zZCwt5D+AYUcMK2hhw4yWny20vSGg==",
             "dependencies": {
-                "load-yaml-file": "^0.2.0",
-                "path-exists": "^4.0.0"
+                "load-yaml-file": "^0.2.0"
             },
             "engines": {
-                "node": ">=8.15"
+                "node": ">=18.12"
             }
         },
         "node_modules/which-pm-runs": {
@@ -8351,6 +8542,11 @@
                 "node": ">=12"
             }
         },
+        "node_modules/xxhash-wasm": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
+            "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A=="
+        },
         "node_modules/yallist": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8365,9 +8561,9 @@
             }
         },
         "node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
             "engines": {
                 "node": ">=12.20"
             },
@@ -8384,11 +8580,20 @@
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.0.tgz",
-            "integrity": "sha512-az0uJ243PxsRIa2x1WmNE/pnuA05gUq/JB8Lwe1EDCCL/Fz9MgjYQ0fPlyc2Tcv6aF2ZA7WM5TWaRZVEFaAIag==",
+            "version": "3.23.3",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+            "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
             "peerDependencies": {
                 "zod": "^3.23.3"
+            }
+        },
+        "node_modules/zod-to-ts": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+            "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+            "peerDependencies": {
+                "typescript": "^4.9.4 || ^5.0.2",
+                "zod": "^3"
             }
         },
         "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@example/starter",
+    "name": "@planarally/docs",
     "version": "0.0.1",
     "private": true,
     "scripts": {
@@ -9,26 +9,26 @@
         "preview": "astro preview"
     },
     "devDependencies": {
-        "@astrojs/vue": "^4.2.0",
-        "@iconify/json": "^2.2.211",
-        "astro": "^4.8.6",
+        "@astrojs/vue": "^4.5.1",
+        "@iconify/json": "^2.2.252",
+        "astro": "^4.15.9",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-vue": "^9.26.0",
-        "prettier": "^3.2.5",
-        "prettier-plugin-astro": "^0.13.0",
-        "sass": "^1.77.2",
-        "unplugin-icons": "^0.19.0",
-        "vue": "^3.4.27"
+        "eslint-plugin-vue": "^9.28.0",
+        "prettier": "^3.3.3",
+        "prettier-plugin-astro": "^0.14.1",
+        "sass-embedded": "^1.79.3",
+        "unplugin-icons": "^0.19.3",
+        "vue": "^3.5.8"
     },
     "dependencies": {
-        "@astrojs/mdx": "^3.0.0",
+        "@astrojs/mdx": "^3.1.7",
         "bufferutil": "^4.0.8",
-        "dayjs": "^1.11.11",
+        "dayjs": "^1.11.13",
         "medium-zoom": "^1.1.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
         "remark-directive": "^3.0.0",
-        "sharp": "^0.33.4"
+        "sharp": "^0.33.5"
     }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types="astro/client" />
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="unplugin-icons/types/vue" />

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -9,7 +9,7 @@ const formattedDate = dayjs(date, "YYYY-MM-DD HH:MM:SS").format("D MMMM YYYY");
 ---
 
 <Main>
-    <HamburgerMenu element="blog-aside" toggleClass="open" client:only />
+    <HamburgerMenu element="blog-aside" toggleClass="open" client:only="vue" />
     <aside id="blog-aside">
         {
             headings.map((header) => {

--- a/src/layouts/docs.astro
+++ b/src/layouts/docs.astro
@@ -12,7 +12,7 @@ if (headings === undefined) headings = Astro.props.content.astro.headings;
 ---
 
 <Main>
-    <HamburgerMenu element="docs-nav" toggleClass="open" client:only />
+    <HamburgerMenu element="docs-nav" toggleClass="open" client:only="vue" />
     <nav id="docs-nav">
         {
             docs.map((doc) => {


### PR DESCRIPTION
Notable changes:

### sass
The upgrade of the `sass` package started spitting out warnings about the legacy api.
So the effort was taken to fix this, by updating the vite config, while also swapping out `sass` for `sass-embedded` which should be more performant.

### HamburgerMenu
This was using the `client:only` directive, but this should now specifically be `client:only="vue"`