### PR TITLE
chore: Replace twitter with discord link

### DIFF
--- a/src/layouts/header.astro
+++ b/src/layouts/header.astro
@@ -1,6 +1,6 @@
 ---
+import Discord from "~icons/fa-brands/discord";
 import Github from "~icons/fa-brands/github";
-import Twitter from "~icons/fa-brands/twitter";
 import NavItem from "../components/NavItem.astro";
 import ThemeSwitcher from "../components/ThemeSwitcher.vue";
 ---
@@ -20,13 +20,13 @@ import ThemeSwitcher from "../components/ThemeSwitcher.vue";
         <!-- search -->
         <ThemeSwitcher client:only="vue" />
         <a
-            aria-label="Twitter"
-            href="//twitter.com/Kruptein"
+            aria-label="discord"
+            href="//discord.gg/mubGnTe"
             rel="noopener noreferrer"
             target="_blank"
-            title="Follow me on Twitter"
+            title="Join us on Discord"
         >
-            <Twitter />
+            <Discord />
         </a>
 
         <a


### PR DESCRIPTION
I only lurk and never post so there was no actual benefit of linking my twitter profile.

Instead a link to the discord server is much more useful for the average visitor.