### PR TITLE
chore(Server): Update the server self-host docs

### DIFF
--- a/src/doc-structure.ts
+++ b/src/doc-structure.ts
@@ -110,7 +110,7 @@ export const docStructure: Record<string, DocsNavigation[]> = {
         {
             title: "Advanced",
             path: "/advanced",
-            items: [{ title: "Reverse proxy setup", path: "/proxy/" }, "Subpath"],
+            items: [{ title: "Reverse proxy", path: "/proxy/" }, "Subpath"],
         },
     ],
 };

--- a/src/pages/server/advanced/proxy.mdx
+++ b/src/pages/server/advanced/proxy.mdx
@@ -2,37 +2,67 @@
 layout: ../../../layouts/docs.astro
 ---
 
-# Reverse proxy setup
+import Warning from "/src/components/directives/Warning.astro";
+
+# Reverse proxy
 
 Commonly when hosting a server, you use some reverse proxy to shield your actual server from the outside world.
-Common solutions are nginx and apache.
+This page provides a set of examples for some popular proxies. Note that some of these have been contributed and not tested/verified by the PA author.
 
-Most aspects of hosting PA are pretty similar to other servers, the one exception is that PA uses a websocket for its communication and this can sometimes require some additional configuration.
+Note that PA can run either in host:port mode or in socket mode. Most proxies can handle either, the examples will usually use one of the two.
+
+A last note is that most examples will have some hardcoded things that you'll have to change. (e.g. "app.planarally.io" is used as the example hostname).
+
+<Warning title="Websocket">
+PA is generally a very normal web server, it however requires websocket connections.
+This can depending on the proxy be a bit more setup.
+
+If you can visit the main PA homepage, but not upload assets or do anything useful in a game, the connection to the websocket most likely is the culprit.
+Either your proxy setup is faulty, or you have cors issues. For the latter double check that the [cors config setting](/server/management/configuration/#field-cors_allowed_origins) is configured correctly
+
+</Warning>
+
+## Caddy
+
+All you need is this:
+
+_Assumes the PA socket is at `/run/pa.sock`. (this is just an example)_
+
+```apache
+app.planarally.io {
+  handle {
+    reverse_proxy unix//run/pa.sock
+  }
+}
+```
+
+Caddy handles the websocket stuff automatically.
+It also does letsencrypt certificates out of the box.
 
 ## Nginx
 
 When using nginx you need to explicitly setup websocket forwarding.
 
-Following is an example config that mimicks my own config.
-In this setup I use a socket to pass the traffic to my server, but an ordinary host\:port combo can also be used.
+Following is an example config that mimicks my old config (before I changed to caddy).
 The important part is that the sockets are passed through.
-I'm no nginx expert so it's definitely possible that this can be simplified, but this should at least work.
+
+This uses a socket setup, if you use a host:port combo, drop the upstream section and just put them in the proxy_pass directly.
 
 ```nginx
 server {
     listen *:443;
     ssl on;
-    ssl_certificate /etc/letsencrypt/live/darragh.dev/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/darragh.dev/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/planarally.io/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/planarally.io/privkey.pem; # managed by Certbot
 
-    server_name planarally.CHANGEME.org;
+    server_name app.planarally.io;
 
-    location /subpath {
+    location / {
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_redirect off;
       proxy_buffering off;
-      proxy_pass http://aiohttp;
+      proxy_pass http://pa_sock;
     }
 
     location /socket.io/ {
@@ -40,7 +70,7 @@ server {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
       proxy_set_header Host $host;
-      proxy_pass http://aiohttp/socket.io/;
+      proxy_pass http://pa_sock/socket.io/;
     }
 
     location /static {
@@ -51,6 +81,10 @@ server {
       allow all;
       root /var/www/letsencrypt;
     }
+}
+
+upstream pa_sock {
+  server unix:/tmp/planarally.sock fail_timeout=0;
 }
 ```
 
@@ -84,4 +118,55 @@ Replace `planarally.CHANGEME.org` with the actual domain name on which PlanarAll
   RewriteCond %{HTTP:Connection} upgrade [NC]
   RewriteRule ^/?(.*) "ws://127.0.0.1:8008/$1" [P,L]
 </VirtualHost>
+```
+
+## Traefik
+
+Here is an example configuration using [docker-compose](https://docs.docker.com/compose/) and
+[traefik](https://containo.us/traefik/), a docker reverse proxy manager. This is assuming that your
+traefik external network is named `web` as well.
+
+#### docker-compose.yml
+
+It is important to note the changes needed to `domain.com` to match your domain and to the paths to both
+the `assets` and `data` folders. These volumes can be whatever you please.
+
+```yaml
+---
+version: "3"
+
+networks:
+    traefik_network:
+        external:
+            name: web
+
+services:
+    # Media Server
+    planarally:
+        image: kruptein/planarally:latest
+        restart: unless-stopped
+        networks:
+            - traefik_network
+        volumes:
+            - "/path/to/data:/planarally/data/"
+            - "/path/to/assets:/planarally/static/assets/"
+        labels:
+            - "traefik.http.services.pa.loadbalancer.server.scheme=http"
+            - "traefik.http.services.pa.loadbalancer.server.port=8000"
+            - "traefik.enable=true"
+            - "traefik.docker.network=web"
+            - "traefik.http.routers.pa-http.service=pa"
+            - "traefik.http.routers.pa-http.rule=Host(`pa.domain.com`)"
+            - "traefik.http.routers.pa-http.entrypoints=http"
+            - "traefik.http.routers.pa.service=pa"
+            - "traefik.http.routers.pa.rule=Host(`pa.domain.com`)"
+            - "traefik.http.routers.pa.entrypoints=https"
+            - "traefik.http.routers.pa.tls=true"
+            - "traefik.http.routers.pa.tls.certresolver=dns"
+            - "traefik.http.routers.pa.tls.domains[0].main=domain.com"
+            - "traefik.http.routers.pa.tls.domains[0].sans=*.domain.com"
+            - "traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https"
+            # these are required, this forces the websocket to forward over https
+            - "traefik.http.routers.pa.middlewares=ssl-header"
+            - "traefik.http.middlewares.ssl-header.headers.customrequestheaders.X-Forwarded-Proto=https"
 ```

--- a/src/pages/server/management/configuration.mdx
+++ b/src/pages/server/management/configuration.mdx
@@ -12,10 +12,11 @@ import Warning from "/src/components/directives/Warning.astro";
     the new format.
 </Warning>
 
-The server can be configured by creating a `config.toml` file in the server's `data` folder.
-When no config file is provided, PA will use default values. The default config can be seen [here](#default-config).
+By default **NO** config file is present. Instead PA uses default values for all the settings. The default config values can be seen [here](#default-config)
 
-When a partial config file is provided, missing fields will similarly be replaced with default values were relevant.
+To change the behaviour, create a `config.toml` file in the server's `data` folder.
+
+When a partial config file is provided, missing fields/sections will be replaced with default values were relevant.
 
 # Format
 
@@ -249,6 +250,9 @@ CORS configuration for the websocket server.
 
 This value is passed to the socketio server, more info can be found in the [socketio](https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class) docs.
 A value of `'*'` can be set to allow all origins, this is useful for testing purposes, but not secure.
+
+This often has to be configured to either the wildcard value (\*) or the correct specific domain in order to work!
+The server console should log when the connection was rejected due to cors.
 
 ### Field: `max_upload_size_in_bytes`
 

--- a/src/pages/server/setup/index.mdx
+++ b/src/pages/server/setup/index.mdx
@@ -4,7 +4,7 @@ layout: ../../../layouts/docs.astro
 
 # Installation
 
-> Installation articles are **only** required reading for the DM.
+> Installation articles are **only** required reading for the DM[^1].
 
 PlanarAlly does not have to be installed by each player, so if you're a player you can go straight ahead to getting started with PlanarAlly or the full docs over [here](/docs/).
 
@@ -32,3 +32,5 @@ That said, I expect most people to not really change much.
 As an online service requires access to the internet, self-hosting is the only approach that offers offline support. You can start your server somewhere in a basement and your players can connect as long as they're on the same network.
 
 Ideally it becomes possible in the future to export your session from online services, so that you can bring your files with you if you would venture into remote areas. But this is alas not yet possible.
+
+[^1]: Technically any person can be the person hosting the server, it does not have to be the DM

--- a/src/pages/server/setup/self-hosting.mdx
+++ b/src/pages/server/setup/self-hosting.mdx
@@ -2,27 +2,174 @@
 layout: ../../../layouts/docs.astro
 ---
 
+import Info from "/src/components/directives/Info.astro";
 import Warning from "/src/components/directives/Warning.astro";
 
 # Self-hosting
 
+## General Info
+
 Hosting PlanarAlly yourself requires a bit more setup then simply using an existing service, but it does give you more control and you can rely on it working offline as well.
 
-To host PlanarAlly yourself you have three options:
+To host PlanarAlly yourself you have four options:
 
-- Perform a manual installation
-- Use a precompiled executable / a pre-built client
-- Use a docker container under Linux
+- Build the client manually and run the server
+- Run the server using a pre-built client
+- Use a docker container
+- Use a precompiled executable
 
-If you simply want to run the latest stable release, you are probably best served with the executables or the releases with pre-built clients which do not require much work.
-In case you do want to have more control over the installation, want to use 'bleeding-edge' dev-builds and/or don't trust some random exe, you should consider performing a manual installation or using docker.
+The first 2 require you to manually install some things (e.g. python, dependencies, ...).\
+Docker allows you to skip a bunch of the manual work, but requires understanding of containers and volumes.
+
+Lastly a .exe is available for people who are not super technical. It should get the job done, but it's less tested.
+
+### Versions
+
+Depending on the chosen option you can decide which version of PA you want to use.
+
+For production versions you can find the official releases [here](https://github.com/Kruptein/PlanarAlly/releases).\
+For a development version you can just check-out any git commit/branch and manually build it.\
+For all releases as well as the development branch, docker images are automatically published on [dockerhub](https://hub.docker.com/r/kruptein/planarally/tags).
+
+### Backups and Upgrades
+
+When backing up your data three folders are important (relative to the server folder):
+
+- data
+- static/assets
+- static/mods
+
+If you made changes to the config (`data/config.toml`) some other folders/files might need to be backed up as well.
+
+When upgrading PA, a migration to the save file (default location `data/planar.sqlite`) might occur. A backup of the current save file will be done to the `save_backups` folder.
+
+<Info>
+If you install PA using one of the release zips/tarballs (e.g. you extract a folder somewhere), it's generally recommended to extract these to a new location and move/copy the above 3 data folders.
+<br />
+Extracting over the existing installation will usually work, but it can sometimes lead to some subtle bugs where a file was removed in the codeabse, but will not be removed by overwriting.
+<br />
+When using git/docker this does not apply.
+
+</Info>
+
+### Configuration
+
+It's normal that you don't find a config file. PA uses default values that are stored internally.
+To override some of these options you can create a `config.toml` file in the server's `data` folder to change the configuration.
+
+See the [config docs](/server/management/configuration/) for the details.
+
+## Fully manual installation
+
+PA consists of two parts:
+
+- a server written in python
+- a frontend written in typescript
+
+While you will always need to run the server to use PA, you only need to re-build the client if you download/change the PA version.
+
+### Frontend
+
+To build the frontend you need `node` and `npm` installed. At the moment of writing at least version 22 of node is required.
+
+```bash
+# You need to be in the client folder to get the client working!
+cd client
+# Update dependencies, a new version usually comes with new dependencies
+npm i
+# Build the server
+npm run build
+```
+
+This will convert the typescript files to a couple minified javascript files and places them in the server's static folder, so that the server can be ran.
+
+That's all!
+
+### Backend
+
+You need a recent version of python installed to run PA. I believe 3.11 is the minimum version, but it's officially tested against 3.13.
+
+You can use any method to install python, but the recommended route is by using [uv](https://docs.astral.sh/uv/getting-started/installation/).
+This will cleanly seperate python installs and is also incredibly fast. Additionally this is used for dependency management by PA itself.
+
+<Info title="Dependencies without uv">
+If you don't want or can't use uv, it should be noted that there is no `requirements.txt` file in the repository.
+PA uses the modern `pyproject.toml` file which uv (as well as other tools) understand.
+
+This means however that you can't do a traditional `pip install -r requirements.txt`. You can find the list of dependencies you need to install in the aforementioned `pyproject.toml` file
+
+</Info>
+
+The following instructions assume you use uv, adapt the commands to your need if you use another approach.
+
+```bash
+# 1. Install python (can be skipped if you already have this)
+uv python install 3.13
+# 2. Move to the server folder!
+# (if you're still in the client folder you need to use `cd ../server`!)
+cd server
+# 3. Create a virtual environment for your python install
+uv venv
+# 4. Install the dependencies
+uv sync
+# 5. Run PA
+uv run planarally.py
+```
+
+When you want to (re)start your server in the future you only need to run step 5.
+If you changed the version of PA you also need to rerun step 4.
+
+## Pre-built client
+
+If you want to manage the server install, but don't want to bother with building the client you can use the pre-built client files.
+These appear as the `Planarally-bin` files in the releases.
+
+These only have a server folder, you can follow the same steps as the fully manual installation above, but skip all the frontend/client related steps.
+
+## Docker Container
+
+### Vanilla
+
+You can grab the [Official Container](https://hub.docker.com/r/kruptein/planarally) with this command.  
+`docker pull kruptein/planarally`
+
+There are 3 volumes that should be mounted to have data persistency:
+
+- data: This is where the configuration as well as the save file usually is stored
+- assets: This is where user uploaded assets are stored
+- mods: This is an optional volume, only required if you allow/use mods on the server.
+
+It's recommended to make explicit volumes for these with `docker volume create` (See https://docs.docker.com/storage/volumes/)
+
+PA runs as a limited user in the docker container, you need to change the ownership of the created volumes to match this:
+
+```
+cd /var/lib/docker/volumes
+sudo chown -R 9000:9000 data/
+# repeat for other volumes
+```
+
+With volumes set up, you're ready to actually run the container.
+
+```
+# PA runs on port 8000, You can drop the mods volume if you don't intend to use it or allow it
+# It's generally recommended to specify a particular tag of the docker image (e.g. v2025.2.2) instead of using the latest
+# New versions can come with database migrations and might require some manual intervention that you want to do when you have some time
+docker run -d -t -p 8000:8000 -v data:/planarally/data/ -v assets:/planarally/static/assets/ -v mods:/planarally/static/mods --name planarally kruptein/planarally
+```
+
+### compose
+
+There is currently no official docker-compose file, but a member of the community once wrote [this guide](https://github.com/edmael/selfhosted-planarally) on using docker-compose, ssl and nginx.
+
+There is also a compose file included in an example setup made for the Traefik reverse proxy, which can be found [here](/server/advanced/proxy/#traefik).
 
 ## Precompiled executable
 
-You can find the latest version [on github](https://github.com/Kruptein/PlanarAlly/releases/).
-Note that the version numbers that are part of the releases' file names, are omitted in this tutorial.
+_Note that the version numbers that are part of the releases' file names, are omitted in this tutorial._
 
-To run PlanarAlly on Windows, download the `planarally-windows.zip` and extract it somewhere in a new folder.
+To run PlanarAlly on Windows, download the `planarally-windows.zip` from the release page and extract it somewhere in a new folder.
+
 This folder contains a lot of different files, but the important one for you right now is the one titled `planarally.exe`.
 When you execute this file, a command prompt will appear (a black screen with some text).
 
@@ -33,149 +180,3 @@ When you execute this file, a command prompt will appear (a black screen with so
     Nevertheless it can happen that a false-positive is triggered by an antivirus vendor out there for various reasons.
 
 </Warning>
-
-## pre-built client
-
-To run PlanarAlly on Linux or Mac, download the `planarally-bin` archives, while choosing your preferred compression method out of `.tar.gz` and `.zip` (content is the same). Extract the content into a new folder, open a terminal navigating into that folder.
-
-Since only the client is pre-built, you need to take care of the python-dependencies yourself. (follow the first section of the manual installation below)
-
-To start the server execute:
-
-```bash
-python3 server/planarally.py
-```
-
-If everything went well you should now be able to visit `http://localhost:8000` and be greeted with the login screen.
-
-## Manual installation
-
-If you want to manually install PlanarAlly, you'll need to make sure you have python 3.6 or newer installed, you can get this from the [python site](https://www.python.org/downloads/).
-
-To get the source files you can either download a zip for a particular version from [github](https://github.com/Kruptein/PlanarAlly/releases/) or
-clone the repository with git.
-
-Everything needed to run PlanarAlly can be found in the `server` folder.
-
-Make sure to install all dependencies by running:
-
-```bash
-pip install --user -r requirements.txt
-```
-
-(If you are familiar with python, it is strongly advised to create a dedicated venv for PA, but this is not a hard requirement.)
-
-### Production Mode
-
-Before the server can be started, you have to build the client.
-This is done by the Node.js package manager _npm_ with the following command:
-
-```bash
-npm i
-npm run build
-```
-
-To run the server you now simply run `python3 planarally.py` and your server should start up.
-
-If everything went well you should now be able to visit `http://localhost:8000` and be greeted with the login screen.
-
-For more information on how to configure your server visit the main [server management](/docs/server/management/) docs.
-
-### Debug/Development Mode
-
-In case you want to install and run the server in debug/development mode, you need to run, in the `client` folder:
-
-```bash
-npm i
-npm run dev
-```
-
-Then, in the `server` folder, run:
-
-```bash
-python3 planarally.py dev
-```
-
-This starts the server in a 'hot module reloading' mode that builds changes made to the sourcecode on the fly instead of waiting for you to manually rebuild.
-At the moment, however, it is required to build the client with `npm run build` once, before you use the _serve_-mode.
-
-## Docker Container
-
-You can grab the [Official Container](https://hub.docker.com/r/kruptein/planarally) with this command.  
-`docker pull kruptein/planarally`
-
-Generally for ease of backup it is recommended to use [volumes](https://docs.docker.com/storage/volumes/) with docker as well.
-
-```bash
-docker volume create data
-docker volume create assets
-```
-
-Both of those commands will create folders in /var/lib/docker/volumes/
-After that, as of the version 0.23 of PlanarAlly you need to change user/group permissions, this can be done with a simple chown command ran on both of your volume folders located in /var/lib/docker/volumes/  
-`sudo chown -R 9000:9000 data/`  
-`sudo chown -R 9000:9000 assets/`
-
-then you can use this next command to start the container  
-`docker run -d -t -p 8000:8000 -v data:/planarally/data/ -v assets:/planarally/static/assets/ --name planarally kruptein/planarally`
-
-then just like it was mentioned in the section above you can just type `http://localhost:8000` and access planarally.
-
-See also this [write up on setting up a server with SSL encryption written by a community member](https://github.com/edmael/selfhosted-planarally) using an nginx reverse proxy as well as docker-compose.
-
-### Docker Container with Docker-Compose and Traefik
-
-Here is an example configuration using [docker-compose](https://docs.docker.com/compose/) and
-[traefik](https://containo.us/traefik/), a docker reverse proxy manager. This is assuming that your
-traefik external network is named `web` as well.
-
-#### docker-compose.yml
-
-It is important to note the changes needed to `domain.com` to match your domain and to the paths to both
-the `assets` and `data` folders. These volumes can be whatever you please.
-
-```yaml
----
-version: "3"
-
-networks:
-    traefik_network:
-        external:
-            name: web
-
-services:
-    # Media Server
-    planarally:
-        image: kruptein/planarally:latest
-        restart: unless-stopped
-        networks:
-            - traefik_network
-        volumes:
-            - "/path/to/data:/planarally/data/"
-            - "/path/to/assets:/planarally/static/assets/"
-        labels:
-            - "traefik.http.services.pa.loadbalancer.server.scheme=http"
-            - "traefik.http.services.pa.loadbalancer.server.port=8000"
-            - "traefik.enable=true"
-            - "traefik.docker.network=web"
-            - "traefik.http.routers.pa-http.service=pa"
-            - "traefik.http.routers.pa-http.rule=Host(`pa.domain.com`)"
-            - "traefik.http.routers.pa-http.entrypoints=http"
-            - "traefik.http.routers.pa.service=pa"
-            - "traefik.http.routers.pa.rule=Host(`pa.domain.com`)"
-            - "traefik.http.routers.pa.entrypoints=https"
-            - "traefik.http.routers.pa.tls=true"
-            - "traefik.http.routers.pa.tls.certresolver=dns"
-            - "traefik.http.routers.pa.tls.domains[0].main=domain.com"
-            - "traefik.http.routers.pa.tls.domains[0].sans=*.domain.com"
-            - "traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https"
-            # these are required, this forces the websocket to forward over https
-            - "traefik.http.routers.pa.middlewares=ssl-header"
-            - "traefik.http.middlewares.ssl-header.headers.customrequestheaders.X-Forwarded-Proto=https"
-```
-
-## Backups
-
-When backing up your data the only items you really need to worry about are _/data/planar.sqlite_ and the _/static/assets/_ directory both of which will be included in the _/planarally_ directory.
-
-planar.sqlite is the main database file. When the server upgrades to a new database format it will create backups in `save_backups/` before proceeding.


### PR DESCRIPTION
This is a cleanup of various documents under the server section.

- The self-host page has been cleaned up and reorganized
- The server install instructions have been updated to use `uv`
- The proxy page introduction has been redone
- A caddy proxy example is added
- The docker traefik example is moved from the self-host page to the proxy page
- The nginx config had a small change
- The configuration intro was slightly rewritten to clarify that a config file is not present by default