### PR TITLE
fix(theme): fix theme toggle logic and handle SSR execution

### DIFF
--- a/src/components/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher.vue
@@ -12,7 +12,7 @@ const darkTheme = ref(false);
 
 function applyTheme(isDark: boolean) {
     darkTheme.value = isDark;
-    
+
     if (isDark) {
         document.body.classList.add("dark-theme");
         document.body.classList.remove("light-theme");
@@ -20,7 +20,7 @@ function applyTheme(isDark: boolean) {
         document.body.classList.remove("dark-theme");
         document.body.classList.add("light-theme");
     }
-    
+
     localStorage.setItem("theme", isDark ? "dark" : "light");
 }
 

--- a/src/components/ThemeSwitcher.vue
+++ b/src/components/ThemeSwitcher.vue
@@ -4,32 +4,41 @@
     The initial theme load is NOT handled by this component to avoid potential micro flashes.
     Instead this is handled by a blocking <script> in the main.astro file.
 */
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 import Sun from "~icons/akar-icons/sun";
 import Moon from "~icons/bx/moon";
 
 const darkTheme = ref(false);
 
-const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
-const currentTheme = localStorage.getItem("theme");
-
-if (currentTheme === "dark") {
-    darkTheme.value = true;
-} else if (currentTheme === "light") {
-    darkTheme.value = false;
-} else {
-    darkTheme.value = prefersDarkScheme.matches;
+function applyTheme(isDark: boolean) {
+    darkTheme.value = isDark;
+    
+    if (isDark) {
+        document.body.classList.add("dark-theme");
+        document.body.classList.remove("light-theme");
+    } else {
+        document.body.classList.remove("dark-theme");
+        document.body.classList.add("light-theme");
+    }
+    
+    localStorage.setItem("theme", isDark ? "dark" : "light");
 }
 
-function toggleTheme() {
-    if (prefersDarkScheme.matches) {
-        document.body.classList.toggle("light-theme");
+onMounted(() => {
+    const currentTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+    if (currentTheme === "dark") {
+        applyTheme(true);
+    } else if (currentTheme === "light") {
+        applyTheme(false);
     } else {
-        document.body.classList.toggle("dark-theme");
+        applyTheme(prefersDark);
     }
-    const theme = document.body.classList.contains("dark-theme") ? "dark" : "light";
-    darkTheme.value = !darkTheme.value;
-    localStorage.setItem("theme", theme);
+});
+
+function toggleTheme() {
+    applyTheme(!darkTheme.value);
 }
 </script>
 


### PR DESCRIPTION
## Summary
Fixed the theme toggle logic in the theme switcher component.
The previous implementation caused state desynchronization between `localStorage`, `document.body` classes, and the Vue reactive state.
It also triggered errors during Astro's SSR phase due to direct access to browser-only APIs (`window` and `localStorage`).

## Changes
- **Unified theme logic**: Added the `applyTheme` helper that synchronously updates the *reactive* state, `document.body` classes (`dark-theme` / `light-theme`), and `localStorage`.
- **SSR compatibility**: Wrapped `window.matchMedia` and `localStorage` checks inside Vue's `onMounted` lifecycle hook to avoid execution during Astro's build/SSR phase.

## How to Test
1. Click the theme switcher button to toggle between Light and Dark mode.
2. Verify that `document.body` receives both the correct `.dark-theme` or `.light-theme` class and that the opposite class is explicitly removed.
3. Check if the value of `theme` changes in `localStorage` during the click event.
4. Test with system dark/light mode enabled to verify initial fallback behavior on clear storage.

Fixes #245 