### PR TITLE
chore: deps

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
             "name": "@planarally/docs",
             "version": "0.0.1",
             "dependencies": {
-                "@astrojs/mdx": "^7.0.2",
+                "@astrojs/mdx": "7.0.6",
                 "bufferutil": "^4.1.0",
-                "dayjs": "^1.11.21",
+                "dayjs": "^1.11.23",
                 "medium-zoom": "^1.1.0",
                 "rehype-autolink-headings": "^7.1.0",
                 "rehype-slug": "^6.0.0",
@@ -18,15 +18,15 @@
                 "sharp": "^0.35.3"
             },
             "devDependencies": {
-                "@astrojs/vue": "^7.0.1",
-                "@iconify/json": "^2.2.498",
-                "astro": "^7.0.7",
-                "globals": "^17.7.0",
-                "oxfmt": "^0.58.0",
-                "oxlint": "^1.73.0",
-                "sass-embedded": "^1.100.0",
+                "@astrojs/vue": "^7.0.2",
+                "@iconify/json": "^2.2.518",
+                "astro": "7.2.3",
+                "globals": "^17.11.0",
+                "oxfmt": "^0.64.0",
+                "oxlint": "^1.79.0",
+                "sass-embedded": "^1.102.0",
                 "unplugin-icons": "^23.0.1",
-                "vue": "^3.5.39"
+                "vue": "^3.5.41"
             }
         },
         "node_modules/@antfu/install-pkg": {
@@ -44,29 +44,29 @@
             }
         },
         "node_modules/@astrojs/compiler-binding": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
-            "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
+            "integrity": "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==",
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@astrojs/compiler-binding-darwin-arm64": "0.3.1",
-                "@astrojs/compiler-binding-darwin-x64": "0.3.1",
-                "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
-                "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
-                "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
-                "@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
-                "@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
-                "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
-                "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
+                "@astrojs/compiler-binding-darwin-arm64": "0.3.2",
+                "@astrojs/compiler-binding-darwin-x64": "0.3.2",
+                "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2",
+                "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2",
+                "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2",
+                "@astrojs/compiler-binding-linux-x64-musl": "0.3.2",
+                "@astrojs/compiler-binding-wasm32-wasi": "0.3.2",
+                "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2",
+                "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2"
             }
         },
         "node_modules/@astrojs/compiler-binding-darwin-arm64": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
-            "integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
+            "integrity": "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==",
             "cpu": [
                 "arm64"
             ],
@@ -80,9 +80,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-darwin-x64": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
-            "integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
+            "integrity": "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==",
             "cpu": [
                 "x64"
             ],
@@ -96,9 +96,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
-            "integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
+            "integrity": "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==",
             "cpu": [
                 "arm64"
             ],
@@ -115,9 +115,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
-            "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
+            "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
             "cpu": [
                 "arm64"
             ],
@@ -134,9 +134,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
-            "integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
+            "integrity": "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==",
             "cpu": [
                 "x64"
             ],
@@ -153,9 +153,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
-            "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
+            "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
             "cpu": [
                 "x64"
             ],
@@ -172,25 +172,25 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
-            "integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
+            "integrity": "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.1.6"
+                "@napi-rs/wasm-runtime": "^1.2.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
-            "integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
+            "integrity": "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==",
             "cpu": [
                 "arm64"
             ],
@@ -204,9 +204,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
-            "integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
+            "integrity": "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==",
             "cpu": [
                 "x64"
             ],
@@ -220,26 +220,26 @@
             }
         },
         "node_modules/@astrojs/compiler-rs": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
-            "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
+            "integrity": "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler-binding": "0.3.1"
+                "@astrojs/compiler-binding": "0.3.2"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@astrojs/internal-helpers": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
-            "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.3.tgz",
+            "integrity": "sha512-HIx/t1NywcqSTFaVwZh15n8JsC3YQdCaJZDaTS/aurYTEvNiWDXUGS3Z9uQX3bFB+B1pCgN/nljckkzYTpHZ2w==",
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.4",
                 "@types/mdast": "^4.0.4",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "picomatch": "^4.0.4",
                 "retext-smartypants": "^6.2.0",
                 "shiki": "^4.0.2",
@@ -248,12 +248,12 @@
             }
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
-            "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.3.tgz",
+            "integrity": "sha512-7ks7U9Tkauw3mgHN1LqKR1qjROF8/8JBivtzlRE5WRZv5xR8UaqsXh5WsxQ5Ij6qJYcGwN9BX4FplUA7J5chIg==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.10.1",
+                "@astrojs/internal-helpers": "0.10.3",
                 "@astrojs/prism": "4.0.2",
                 "github-slugger": "^2.0.0",
                 "hast-util-from-html": "^2.0.3",
@@ -272,26 +272,14 @@
                 "vfile": "^6.0.3"
             }
         },
-        "node_modules/@astrojs/markdown-satteri": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.3.tgz",
-            "integrity": "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==",
-            "license": "MIT",
-            "dependencies": {
-                "@astrojs/internal-helpers": "0.10.1",
-                "@astrojs/prism": "4.0.2",
-                "github-slugger": "^2.0.0",
-                "satteri": "^0.9.1"
-            }
-        },
         "node_modules/@astrojs/mdx": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.2.tgz",
-            "integrity": "sha512-l+sJY5U1KkGZUdr+bIL4Y6BefeS549qoSHVSkUSs6A9INwdCND+/0+vN0NroPBXwl5Vcg5u78t7VQRsJjePxbw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.6.tgz",
+            "integrity": "sha512-/qVA/+GAXtBd8eJ39HsOgDwWHtt50OUcdef4QMDfWcgmzDlLm0nG4udy92FTbWbM11R7GmPOzhfofO63ycEfRg==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/internal-helpers": "0.10.1",
-                "@astrojs/markdown-remark": "7.2.1",
+                "@astrojs/internal-helpers": "0.10.3",
+                "@astrojs/markdown-remark": "7.2.3",
                 "@mdx-js/mdx": "^3.1.1",
                 "acorn": "^8.16.0",
                 "es-module-lexer": "^2.0.0",
@@ -346,9 +334,9 @@
             }
         },
         "node_modules/@astrojs/vue": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/vue/-/vue-7.0.1.tgz",
-            "integrity": "sha512-DHTZ1QKlLZ8ZSrqmQ7KMjsyGLitgLYM9ynFRc55ZKr9Jrb6yIuVRRRHbzsqXXI87oc3dwObxEhEaWPgJe7Dq/w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/vue/-/vue-7.0.2.tgz",
+            "integrity": "sha512-5vKGat4wYyN7l71iGF9cA79GeuLtPVoL+4b7NPQ7scKyq8HQp37XTXNqjV1v+lYsCW4Tmu0S2gH4453KbrTyaQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -645,12 +633,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.7"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -809,9 +797,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.29.7",
@@ -834,67 +822,6 @@
                 "darwin"
             ]
         },
-        "node_modules/@bruits/satteri-darwin-x64": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
-            "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@bruits/satteri-linux-arm64-gnu": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
-            "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
-            "cpu": [
-                "arm64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@bruits/satteri-linux-arm64-musl": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
-            "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@bruits/satteri-linux-x64-gnu": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
-            "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
-            "cpu": [
-                "x64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
         "node_modules/@bruits/satteri-linux-x64-musl": {
             "version": "0.9.5",
             "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
@@ -909,71 +836,6 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@bruits/satteri-wasm32-wasi": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
-            "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
-                "@napi-rs/wasm-runtime": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@bruits/satteri-win32-arm64-msvc": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
-            "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@bruits/satteri-win32-x64-msvc": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
-            "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
             ]
         },
         "node_modules/@bufbuild/protobuf": {
@@ -1472,9 +1334,9 @@
             }
         },
         "node_modules/@iconify/json": {
-            "version": "2.2.498",
-            "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.498.tgz",
-            "integrity": "sha512-aHeANR4JvpCcGZBOHXwsPDf8C5YtrZjZjb7NwC8kwoVRtA2vyQImp5U3wzqe8HIbKgQgjAtqYEPPVHtqIj62JA==",
+            "version": "2.2.518",
+            "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.518.tgz",
+            "integrity": "sha512-RhUkCc/lF+0hWiYLIMPOf4oy5owjN8r9PGqDQKb7bh76QiWHTerIApDhtOcEWe85VjUcsuU88Rg56Od+a64wMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2135,21 +1997,24 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+            "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@tybys/wasm-util": "^0.10.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
             },
             "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
+                "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+                "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
             }
         },
         "node_modules/@oslojs/encoding": {
@@ -2167,9 +2032,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.58.0.tgz",
-            "integrity": "sha512-Uz62sHduGGPftXtILGyxdSW4PX82rUg+rfdNqhsgxe881g4rIoXlIqmZQ6HVKcF4f+F8qMhdD03Bx5u7gmeTdg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.64.0.tgz",
+            "integrity": "sha512-o6uzh/jTOQeAY5TdkAeXdqv7MBRcPxiRA08zrcBtkKj5cSu/FMu0Hl7Q6Fi1KCKyCWZ6lJVjBzdsJvsKltUsGQ==",
             "cpu": [
                 "arm"
             ],
@@ -2184,9 +2049,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.58.0.tgz",
-            "integrity": "sha512-rD0lRaJp1b+9vw6X4A2dJWKukd6X8yxiicN4JxXcXayolmUypRZxk+lKR+fVOu5q/iYc0fh5fR4bgmfOfVlbaA==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.64.0.tgz",
+            "integrity": "sha512-jRGSUeeP7p3Gynw2YaCVtjBIA6ZxY6bEB/ES5i54OhqmRTyuVg7ZgstEtzgq6GOAJd+2QZ5pvf+bFfmW5Mp9cw==",
             "cpu": [
                 "arm64"
             ],
@@ -2201,9 +2066,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.58.0.tgz",
-            "integrity": "sha512-uzbPPk7O6M+w2K65vcQ1woga3wgP8zghjL1KOG5b6qJ8dvYHZJ1VShaslg2KOK6yQIwCQtcMCXqLBM6sqXUNTg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.64.0.tgz",
+            "integrity": "sha512-JINwtU2lW7nOFSqi+H2qplipNUqah9Gc1jgGmB82kTD4UnZrZIVxCJ9qEmFiKfjNq27gYLFhrUb0to86aCwMjw==",
             "cpu": [
                 "arm64"
             ],
@@ -2218,9 +2083,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.58.0.tgz",
-            "integrity": "sha512-L0nKYDxU32oxeQqJj21W9SlIMnf81VZEhyah6iDvFhf5q0oynq498Fopth7blErUJVBpVtxQ98RMCfMPqpJX6w==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.64.0.tgz",
+            "integrity": "sha512-gCmuswrgrOSajV4HCRFkVCGIruPq8bjYuPYgSE2WQB3mD6XrdyZ3JMSRZCkQ8zCxOyGWriBo6QoZ5nmMHQ1BfA==",
             "cpu": [
                 "x64"
             ],
@@ -2235,9 +2100,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.58.0.tgz",
-            "integrity": "sha512-woNwfD58dC5PGS9LSLSD5JYfo/EFK5iG9vhDWkcCg3q78ag7KC8bpDqgvPHrMoXpx83OLXxoSOhu6z8FsVTHlg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.64.0.tgz",
+            "integrity": "sha512-Ab8g7a38pT0MMImjh7anRSTve6buWBIlcXIFBYa5xl4s6UxEgKSc2xOOhbGtLwvXnEi2PsEDGoJh3oUU7xkehQ==",
             "cpu": [
                 "x64"
             ],
@@ -2252,9 +2117,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.58.0.tgz",
-            "integrity": "sha512-Sqs8nMLxuQpY21NKJ1u4stPDmO5hskBCNNh2E3AdCfI1QqWtf4m+Qn4mGEIUO4KGmuq3SWc/SZ80uy5IiwTCDw==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.64.0.tgz",
+            "integrity": "sha512-BgvS3CoQ+Xy2deoZqEN8JVKabcCZi2RxA3yant8G9OAv9KuPJ9TCjHkqigzdHUVwErZxEP5d2bzLIEyKYyBDLg==",
             "cpu": [
                 "arm"
             ],
@@ -2269,9 +2134,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.58.0.tgz",
-            "integrity": "sha512-Vd4exzBI5B5hB9m22JiTQzIL23WvHo/Pe+sNXPNeBLXSP9swCBPKCEBRwKpmpQzYhlgYaCgfPcGXPKAJBRIiZQ==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.64.0.tgz",
+            "integrity": "sha512-QXpNxwoMj0YvnceCNZadNSden3bIcnvjn/sDp/rwZhRoZoZYGpHvtPyhGsdJz9uvT9GkaMW7SsLddurU56dt8w==",
             "cpu": [
                 "arm"
             ],
@@ -2286,9 +2151,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.58.0.tgz",
-            "integrity": "sha512-bUWi5mHV+4Vi56RLHE1h6q/HHfwAIT3XoB9vJAVeRzfu5NriXM8y6eeJu0vlKa0C9kq2rq1sOWRClhdLHPocrg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.64.0.tgz",
+            "integrity": "sha512-BBgH3I1ppDsI5pZ4Pdhw0ceYxwVCfbU/bZEBCeZ6caRS9x0ZabErxubP7riGUn11PXZBhe8DYdjkDKP1FlVQ5w==",
             "cpu": [
                 "arm64"
             ],
@@ -2306,9 +2171,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.58.0.tgz",
-            "integrity": "sha512-2ZHxemzgHcjtktAuVUwSoyXmGo/t+aF5tS1ciPpPei4rhSyrz3JOqDosXXrmhN/yLUSzJjtuW7ToTWqfQpCj2w==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.64.0.tgz",
+            "integrity": "sha512-v19HSjC/BGXdt26qEvKZtwAHgGmQ2Agcap2kQP+KIqoRZqivVzYth3ui2dJA1i+6/fjpjga85lIOaJJjQ/bOOw==",
             "cpu": [
                 "arm64"
             ],
@@ -2326,9 +2191,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.58.0.tgz",
-            "integrity": "sha512-AwKkVwjVmFQ3bcO7j0McGYAqCKH2a326fswfofng/E8VewCT/raeeGQr4huVhY704deK8AWASSTlxzMj0eZc6Q==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.64.0.tgz",
+            "integrity": "sha512-PElLnOo4xFTBZrxPhgTIj0eHqZXwEBQoNWtb7facUV170T0B0FRET0iNbb3LUeLWTybkUW+vsdyv4ihOdyXGyw==",
             "cpu": [
                 "ppc64"
             ],
@@ -2346,9 +2211,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.58.0.tgz",
-            "integrity": "sha512-xsRpTxfUnJF8D3AUKko/qyWdjw4GZVHlCVFuGlzSCTeewLmykKINW8em1+wx+axsDVtJJcMtvsiaXggXxrlHgw==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.64.0.tgz",
+            "integrity": "sha512-Qzsg15n4F5CH+MorcRW4MkAEMiLzXmeG+DiDSbP/bBTqCmWOH3K9DHryNrve+JHlV0txS+B6Z9P5Xz+cmWeL+g==",
             "cpu": [
                 "riscv64"
             ],
@@ -2366,9 +2231,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.58.0.tgz",
-            "integrity": "sha512-Z4AYOTcy7nYEIiXwD62PlerimyYRcfJOgUbQAEBjXz098kxKuERBlRntofGy69HHhe9E0TLVNMl1yspVNu+efw==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.64.0.tgz",
+            "integrity": "sha512-/GZ358wnQ/Ez4UVnCcZIi56JkY0sOdZ+B108pqXKqZz3jLS59F4KEAB1Qv3fRlObrFEk+3L2vUQ/xoPx+3vjXw==",
             "cpu": [
                 "riscv64"
             ],
@@ -2386,9 +2251,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.58.0.tgz",
-            "integrity": "sha512-A3nhhtZPC/TKVWOPj9q/H3p2znJDCcHWYlJBhWL8hGq/bFmBaNBHC8Np6E581yVq1w9Mi3rMDNzDalWvtUfJtQ==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.64.0.tgz",
+            "integrity": "sha512-/C9We3DXegowfLXtVCYHeNiU9azwCDr5cQkEtCVlc74vyn+lLQSPApJ1CZmxAduqeq/Oi3gQ+IVptyhCaTMtkQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2406,9 +2271,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.58.0.tgz",
-            "integrity": "sha512-2g+tVkgwqphw8R4hgo+kF4oz8+P5RwVOtr9+irsC7uwEp0e9j7Crw8kDGKL20uYlLPD7g02DqA61mC/UNYx98A==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.64.0.tgz",
+            "integrity": "sha512-91KM2CeRWscIEHlj1NsW2WSnzGeq1Ehq+39bfDowTdkn+fcvK/x4Y1RcyqT7glyBjZio0ldkeCG6Usj3v7ASog==",
             "cpu": [
                 "x64"
             ],
@@ -2426,9 +2291,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.58.0.tgz",
-            "integrity": "sha512-rc15P6AbyyB7426aN8AakLd02Trb3a6ML/mmfAQeVHJEfVofWLcWIrBdy6zDEY+DIaL/s8E4GGPboVw+oP3+EA==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.64.0.tgz",
+            "integrity": "sha512-gw7uEk9I+7zoT1EYLra1eWArIzNcz8e3jkv+Noo2+o2T7wPvsNSQbfoa4DSfZlvn1i6mJ05RiZ4/omaXPDNhQg==",
             "cpu": [
                 "x64"
             ],
@@ -2446,9 +2311,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.58.0.tgz",
-            "integrity": "sha512-ZWoTM27/HYPOh9iq86DAbhPu9nXb8qKvvGU/h8OfliyVUFAMMNTLDkGsWDKKnDqIkqvZ9+dXlgUOsH1LYO3O7g==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.64.0.tgz",
+            "integrity": "sha512-HYHFf616FHSPSO07c09mjmXBfQ73wIVM3m0txOiooa5XZkGoxFd6B14PVj0LB0DXIqJ6wAO/dDR/NX/5UUaqnw==",
             "cpu": [
                 "arm64"
             ],
@@ -2463,9 +2328,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.58.0.tgz",
-            "integrity": "sha512-LHZnqFXe2dEfkRI4XdZS/57nEOT/I4UCRX5IyM9v4GYW9XwQCjGe1IUK59SuKw3POwvcgWQ4pme2cYXmNqTNPg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.64.0.tgz",
+            "integrity": "sha512-uQjFp081IZSWD6VAofX2iO2z01awAdHmfC+NrieWIPKrT2hZKQDyq/U18M7ifC0sm0Wz8aHY/p6+FDYIzs/CrQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2480,9 +2345,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.58.0.tgz",
-            "integrity": "sha512-mZKpg20TpheCJym1rarcZCUJeW1sSruw8zAAaCYWvuVfwIUDN1CXdrPU/JgCWReXTCTrEfCB8Wyo3hh9jSZ2EA==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.64.0.tgz",
+            "integrity": "sha512-lNM6byTAQ881jugzFu8juJTbNRgsUTlswMA6pJmwi1XDvmIqnnb49lcUAs5gz94fCJLrVN+/X3s3jOKqx23WIQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2497,9 +2362,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.58.0.tgz",
-            "integrity": "sha512-N/wUU4N5PZ2orBtI+Ko7MnMfYLfE7K91UrGMY/c/pYyHR3lA9kwst1XugkZx+92YcRh/Eo+iv2eTESSWXfiZPA==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.64.0.tgz",
+            "integrity": "sha512-BtmbtL/QjMtF1a6C3CqoDluH2IfB6fJt62E+B9RFfUPtFk4Iz9PFS6+y/SzzOvSxc7aUk2Kphwg7Dh8lMbwu6g==",
             "cpu": [
                 "x64"
             ],
@@ -2514,9 +2379,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.73.0.tgz",
-            "integrity": "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz",
+            "integrity": "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==",
             "cpu": [
                 "arm"
             ],
@@ -2531,9 +2396,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.73.0.tgz",
-            "integrity": "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz",
+            "integrity": "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==",
             "cpu": [
                 "arm64"
             ],
@@ -2548,9 +2413,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.73.0.tgz",
-            "integrity": "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz",
+            "integrity": "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==",
             "cpu": [
                 "arm64"
             ],
@@ -2565,9 +2430,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.73.0.tgz",
-            "integrity": "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz",
+            "integrity": "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==",
             "cpu": [
                 "x64"
             ],
@@ -2582,9 +2447,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.73.0.tgz",
-            "integrity": "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz",
+            "integrity": "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==",
             "cpu": [
                 "x64"
             ],
@@ -2599,9 +2464,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.73.0.tgz",
-            "integrity": "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz",
+            "integrity": "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==",
             "cpu": [
                 "arm"
             ],
@@ -2616,9 +2481,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.73.0.tgz",
-            "integrity": "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz",
+            "integrity": "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==",
             "cpu": [
                 "arm"
             ],
@@ -2633,9 +2498,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.73.0.tgz",
-            "integrity": "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz",
+            "integrity": "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==",
             "cpu": [
                 "arm64"
             ],
@@ -2653,9 +2518,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.73.0.tgz",
-            "integrity": "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz",
+            "integrity": "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==",
             "cpu": [
                 "arm64"
             ],
@@ -2673,9 +2538,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.73.0.tgz",
-            "integrity": "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz",
+            "integrity": "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==",
             "cpu": [
                 "ppc64"
             ],
@@ -2693,9 +2558,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.73.0.tgz",
-            "integrity": "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz",
+            "integrity": "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2713,9 +2578,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.73.0.tgz",
-            "integrity": "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz",
+            "integrity": "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2733,9 +2598,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.73.0.tgz",
-            "integrity": "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz",
+            "integrity": "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==",
             "cpu": [
                 "s390x"
             ],
@@ -2753,9 +2618,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.73.0.tgz",
-            "integrity": "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz",
+            "integrity": "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==",
             "cpu": [
                 "x64"
             ],
@@ -2773,9 +2638,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.73.0.tgz",
-            "integrity": "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz",
+            "integrity": "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==",
             "cpu": [
                 "x64"
             ],
@@ -2793,9 +2658,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.73.0.tgz",
-            "integrity": "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz",
+            "integrity": "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2810,9 +2675,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.73.0.tgz",
-            "integrity": "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz",
+            "integrity": "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==",
             "cpu": [
                 "arm64"
             ],
@@ -2827,9 +2692,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.73.0.tgz",
-            "integrity": "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz",
+            "integrity": "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==",
             "cpu": [
                 "ia32"
             ],
@@ -2844,9 +2709,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.73.0.tgz",
-            "integrity": "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz",
+            "integrity": "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==",
             "cpu": [
                 "x64"
             ],
@@ -3468,34 +3333,6 @@
             "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "license": "MIT"
         },
-        "node_modules/@rollup/pluginutils": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-walker": "^2.0.2",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "license": "MIT"
-        },
         "node_modules/@shikijs/core": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
@@ -3630,9 +3467,10 @@
             }
         },
         "node_modules/@types/hast": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -3768,14 +3606,14 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
-            "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+            "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@vue/shared": "3.5.39",
+                "@babel/parser": "^7.29.8",
+                "@vue/shared": "3.5.41",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
@@ -3802,31 +3640,31 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
-            "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+            "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.39",
-                "@vue/shared": "3.5.39"
+                "@vue/compiler-core": "3.5.41",
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
-            "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+            "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@vue/compiler-core": "3.5.39",
-                "@vue/compiler-dom": "3.5.39",
-                "@vue/compiler-ssr": "3.5.39",
-                "@vue/shared": "3.5.39",
+                "@babel/parser": "^7.29.8",
+                "@vue/compiler-core": "3.5.41",
+                "@vue/compiler-dom": "3.5.41",
+                "@vue/compiler-ssr": "3.5.41",
+                "@vue/shared": "3.5.41",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.15",
+                "postcss": "^8.5.19",
                 "source-map-js": "^1.2.1"
             }
         },
@@ -3837,14 +3675,14 @@
             "dev": true
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
-            "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+            "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.39",
-                "@vue/shared": "3.5.39"
+                "@vue/compiler-dom": "3.5.41",
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/devtools-core": {
@@ -3882,57 +3720,55 @@
             "license": "MIT"
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
-            "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+            "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.39"
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
-            "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+            "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.39",
-                "@vue/shared": "3.5.39"
+                "@vue/reactivity": "3.5.41",
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
-            "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+            "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.39",
-                "@vue/runtime-core": "3.5.39",
-                "@vue/shared": "3.5.39",
+                "@vue/reactivity": "3.5.41",
+                "@vue/runtime-core": "3.5.41",
+                "@vue/shared": "3.5.41",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
-            "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+            "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.39",
-                "@vue/shared": "3.5.39"
-            },
-            "peerDependencies": {
-                "vue": "3.5.39"
+                "@vue/compiler-ssr": "3.5.41",
+                "@vue/runtime-dom": "3.5.41",
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
-            "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+            "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
             "dev": true,
             "license": "MIT"
         },
@@ -3966,6 +3802,21 @@
             },
             "bin": {
                 "am-i-vibing": "dist/cli.mjs"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/ansis": {
@@ -4021,6 +3872,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
             "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -4036,43 +3888,43 @@
             }
         },
         "node_modules/astro": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-7.0.7.tgz",
-            "integrity": "sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.3.tgz",
+            "integrity": "sha512-CDf55Cw2nOev5BAM72yn7JQMpK/ByTY5tLSybbHbtZNSiMKk0OeyvCjA2foEUXfHXbATpHQQPBgfuXL8PdofcA==",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler-rs": "^0.3.0",
-                "@astrojs/internal-helpers": "0.10.1",
-                "@astrojs/markdown-satteri": "0.3.3",
+                "@astrojs/compiler-rs": "^0.3.2",
+                "@astrojs/internal-helpers": "0.10.3",
+                "@astrojs/markdown-satteri": "0.3.6",
                 "@astrojs/telemetry": "3.3.3",
                 "@capsizecss/unpack": "^4.0.0",
                 "@clack/prompts": "^1.1.0",
                 "@oslojs/encoding": "^1.1.0",
-                "@rollup/pluginutils": "^5.3.0",
                 "am-i-vibing": "^0.4.0",
                 "aria-query": "^5.3.2",
                 "axobject-query": "^4.1.0",
                 "ci-info": "^4.4.0",
                 "clsx": "^2.1.1",
                 "common-ancestor-path": "^2.0.0",
-                "cookie": "^1.1.1",
+                "cookie": "^2.0.1",
                 "devalue": "^5.8.1",
                 "diff": "^8.0.3",
                 "dset": "^3.1.4",
                 "es-module-lexer": "^2.0.0",
                 "esbuild": "^0.28.0",
+                "find-process": "^2.1.1",
                 "flattie": "^1.1.1",
                 "fontace": "~0.4.1",
                 "get-tsconfig": "5.0.0-beta.4",
                 "github-slugger": "^2.0.0",
                 "html-escaper": "3.0.3",
                 "http-cache-semantics": "^4.2.0",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "jsonc-parser": "^3.3.1",
-                "magic-string": "^0.30.21",
+                "magic-string": "^1.0.0",
                 "magicast": "^0.5.2",
                 "mrmime": "^2.0.1",
-                "neotraverse": "^0.6.18",
+                "neotraverse": "^1.0.1",
                 "obug": "^2.1.1",
                 "p-limit": "^7.3.0",
                 "p-queue": "^9.1.0",
@@ -4087,7 +3939,7 @@
                 "tinyexec": "^1.0.4",
                 "tinyglobby": "^0.2.15",
                 "ultrahtml": "^1.6.0",
-                "unifont": "~0.7.4",
+                "unifont": "~0.7.5",
                 "unstorage": "^1.17.5",
                 "vite": "^8.0.13",
                 "vitefu": "^1.1.2",
@@ -4111,12 +3963,183 @@
                 "sharp": "^0.34.0 || ^0.35.0"
             },
             "peerDependencies": {
-                "@astrojs/markdown-remark": "7.2.1"
+                "@astrojs/markdown-remark": "7.2.3"
             },
             "peerDependenciesMeta": {
                 "@astrojs/markdown-remark": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/astro/node_modules/@astrojs/markdown-satteri": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.6.tgz",
+            "integrity": "sha512-kkeWP4Lh6Do/qz2R0DIAtPWCh6WPr1J4UrzDItVmHMK1HwyLHxG4JxM8uBNavhD7ivGOO9BUTsAP5D7ppa68CA==",
+            "license": "MIT",
+            "dependencies": {
+                "@astrojs/internal-helpers": "0.10.3",
+                "@astrojs/prism": "4.0.2",
+                "github-slugger": "^2.0.0",
+                "hast-util-from-html": "^2.0.3",
+                "satteri": "^0.9.1"
+            }
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-darwin-x64": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+            "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-linux-arm64-gnu": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+            "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-linux-arm64-musl": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+            "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-linux-x64-gnu": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+            "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-wasm32-wasi": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+            "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-win32-arm64-msvc": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+            "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/astro/node_modules/@bruits/satteri-win32-x64-msvc": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+            "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/astro/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/astro/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/astro/node_modules/magic-string": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.1.tgz",
+            "integrity": "sha512-vCfXkt3lIJha02CjPT1igeysyHVfCsEpIeD20O+X9aJ2hML3/kKx8E9Iv1FB+aMSAlDOEAtpRWzuooQCrYwdUg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/astro/node_modules/satteri": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+            "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.5",
+                "@types/hast": "^3.0.4",
+                "@types/mdast": "^4.0.4",
+                "@types/unist": "^3.0.3"
+            },
+            "optionalDependencies": {
+                "@bruits/satteri-darwin-arm64": "0.9.5",
+                "@bruits/satteri-darwin-x64": "0.9.5",
+                "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+                "@bruits/satteri-linux-arm64-musl": "0.9.5",
+                "@bruits/satteri-linux-x64-gnu": "0.9.5",
+                "@bruits/satteri-linux-x64-musl": "0.9.5",
+                "@bruits/satteri-wasm32-wasi": "0.9.5",
+                "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+                "@bruits/satteri-win32-x64-msvc": "0.9.5"
             }
         },
         "node_modules/astro/node_modules/semver": {
@@ -4269,6 +4292,34 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/character-entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4353,12 +4404,34 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/colorjs.io": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
-            "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-            "devOptional": true,
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
+        },
+        "node_modules/colorjs.io": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+            "integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
+            "devOptional": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/color"
+            }
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
@@ -4402,12 +4475,12 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+            "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "funding": {
                 "type": "opencollective",
@@ -4511,9 +4584,9 @@
             "license": "MIT"
         },
         "node_modules/dayjs": {
-            "version": "1.11.21",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-            "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+            "version": "1.11.23",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+            "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -4825,6 +4898,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/estree-util-attach-comments": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
@@ -4974,6 +5059,29 @@
                 }
             }
         },
+        "node_modules/find-process": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/find-process/-/find-process-2.1.1.tgz",
+            "integrity": "sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "~4.1.2",
+                "commander": "^14.0.3",
+                "loglevel": "^1.9.2"
+            },
+            "bin": {
+                "find-process": "dist/cjs/bin/find-process.js"
+            }
+        },
+        "node_modules/find-process/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/flattie": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -5048,9 +5156,9 @@
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
         },
         "node_modules/globals": {
-            "version": "17.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-            "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+            "version": "17.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5081,7 +5189,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -5161,9 +5268,10 @@
             }
         },
         "node_modules/hast-util-raw": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.1.tgz",
-            "integrity": "sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
@@ -5293,14 +5401,15 @@
             }
         },
         "node_modules/hast-util-to-parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
-            "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
                 "devlop": "^1.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
@@ -5308,6 +5417,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5/node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/hast-util-to-string": {
@@ -5576,9 +5695,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",
@@ -5915,6 +6034,19 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
+        "node_modules/loglevel": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+            "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
+        },
         "node_modules/longest-streak": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -5938,6 +6070,7 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5967,9 +6100,10 @@
             }
         },
         "node_modules/markdown-table": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -6010,9 +6144,10 @@
             }
         },
         "node_modules/mdast-util-find-and-replace": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
-            "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "escape-string-regexp": "^5.0.0",
@@ -6022,17 +6157,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mdast-util-from-markdown": {
@@ -6059,9 +6183,10 @@
             }
         },
         "node_modules/mdast-util-gfm": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
-            "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
             "dependencies": {
                 "mdast-util-from-markdown": "^2.0.0",
                 "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -6077,9 +6202,10 @@
             }
         },
         "node_modules/mdast-util-gfm-autolink-literal": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
-            "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "ccount": "^2.0.0",
@@ -6093,9 +6219,10 @@
             }
         },
         "node_modules/mdast-util-gfm-footnote": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
-            "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.1.0",
@@ -6112,6 +6239,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
             "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
@@ -6126,6 +6254,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
             "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -6142,6 +6271,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
             "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -6396,6 +6526,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
             "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-extension-gfm-autolink-literal": "^2.0.0",
                 "micromark-extension-gfm-footnote": "^2.0.0",
@@ -6412,9 +6543,10 @@
             }
         },
         "node_modules/micromark-extension-gfm-autolink-literal": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.0.0.tgz",
-            "integrity": "sha512-rTHfnpt/Q7dEAK1Y5ii0W8bhfJlVJFnJMHIPisfPK3gpVNuOP0VnRl96+YJ3RYWV/P4gFeQoGKNlT3RhuvpqAg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-sanitize-uri": "^2.0.0",
@@ -6427,9 +6559,10 @@
             }
         },
         "node_modules/micromark-extension-gfm-footnote": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.0.0.tgz",
-            "integrity": "sha512-6Rzu0CYRKDv3BfLAUnZsSlzx3ak6HAoI85KTiijuKIz5UxZxbUI+pD6oHgw+6UtQuiRwnGRhzMmPRv4smcz0fg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-core-commonmark": "^2.0.0",
@@ -6446,9 +6579,10 @@
             }
         },
         "node_modules/micromark-extension-gfm-strikethrough": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.0.0.tgz",
-            "integrity": "sha512-c3BR1ClMp5fxxmwP6AoOY2fXO9U8uFMKs4ADD66ahLTNcwzSCyRVU4k7LPV5Nxo/VJiR4TdzxRQY2v3qIUceCw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-chunked": "^2.0.0",
@@ -6463,9 +6597,10 @@
             }
         },
         "node_modules/micromark-extension-gfm-table": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.0.0.tgz",
-            "integrity": "sha512-PoHlhypg1ItIucOaHmKE8fbin3vTLpDOUg8KAr8gRCF1MOZI9Nquq2i/44wFvviM4WuxJzc3demT8Y3dkfvYrw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -6482,6 +6617,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
             "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-types": "^2.0.0"
             },
@@ -6491,9 +6627,10 @@
             }
         },
         "node_modules/micromark-extension-gfm-task-list-item": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.0.1.tgz",
-            "integrity": "sha512-cY5PzGcnULaN5O7T+cOzfMoHjBW7j+T9D2sucA5d/KbsBTPcYdebm9zUd9zzdgJGCwahV+/W78Z3nbulBYVbTw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -7061,9 +7198,9 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -7079,9 +7216,10 @@
             }
         },
         "node_modules/neotraverse": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+            "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             }
@@ -7223,9 +7361,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.58.0.tgz",
-            "integrity": "sha512-8feG/7NVEHDVwc1OUpP6Pks+TnaDFUw2jLLFIMi5bcmmwxAX2wBQvjSzj62RRTYBf2Op1Wt8xbkmagmPTR5ETg==",
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.64.0.tgz",
+            "integrity": "sha512-XZ4GFBN/PLbXKq+0zrgpQfPKYuJlUuj+nzZJY7UpIbFMNyefNLCdN9EwViycNqnYcv0wrn0jXcQLlqJp8RCKBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7241,25 +7379,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.58.0",
-                "@oxfmt/binding-android-arm64": "0.58.0",
-                "@oxfmt/binding-darwin-arm64": "0.58.0",
-                "@oxfmt/binding-darwin-x64": "0.58.0",
-                "@oxfmt/binding-freebsd-x64": "0.58.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.58.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.58.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.58.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.58.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.58.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.58.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.58.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.58.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.58.0",
-                "@oxfmt/binding-linux-x64-musl": "0.58.0",
-                "@oxfmt/binding-openharmony-arm64": "0.58.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.58.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.58.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.58.0"
+                "@oxfmt/binding-android-arm-eabi": "0.64.0",
+                "@oxfmt/binding-android-arm64": "0.64.0",
+                "@oxfmt/binding-darwin-arm64": "0.64.0",
+                "@oxfmt/binding-darwin-x64": "0.64.0",
+                "@oxfmt/binding-freebsd-x64": "0.64.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.64.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.64.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.64.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.64.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.64.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.64.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.64.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.64.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.64.0",
+                "@oxfmt/binding-linux-x64-musl": "0.64.0",
+                "@oxfmt/binding-openharmony-arm64": "0.64.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.64.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.64.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.64.0"
             },
             "peerDependencies": {
                 "svelte": "^5.0.0",
@@ -7275,9 +7413,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.73.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.73.0.tgz",
-            "integrity": "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==",
+            "version": "1.79.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz",
+            "integrity": "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7290,28 +7428,28 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.73.0",
-                "@oxlint/binding-android-arm64": "1.73.0",
-                "@oxlint/binding-darwin-arm64": "1.73.0",
-                "@oxlint/binding-darwin-x64": "1.73.0",
-                "@oxlint/binding-freebsd-x64": "1.73.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.73.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.73.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.73.0",
-                "@oxlint/binding-linux-arm64-musl": "1.73.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.73.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.73.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.73.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.73.0",
-                "@oxlint/binding-linux-x64-gnu": "1.73.0",
-                "@oxlint/binding-linux-x64-musl": "1.73.0",
-                "@oxlint/binding-openharmony-arm64": "1.73.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.73.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.73.0",
-                "@oxlint/binding-win32-x64-msvc": "1.73.0"
+                "@oxlint/binding-android-arm-eabi": "1.79.0",
+                "@oxlint/binding-android-arm64": "1.79.0",
+                "@oxlint/binding-darwin-arm64": "1.79.0",
+                "@oxlint/binding-darwin-x64": "1.79.0",
+                "@oxlint/binding-freebsd-x64": "1.79.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.79.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.79.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.79.0",
+                "@oxlint/binding-linux-arm64-musl": "1.79.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.79.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.79.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.79.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.79.0",
+                "@oxlint/binding-linux-x64-gnu": "1.79.0",
+                "@oxlint/binding-linux-x64-musl": "1.79.0",
+                "@oxlint/binding-openharmony-arm64": "1.79.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.79.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.79.0",
+                "@oxlint/binding-win32-x64-msvc": "1.79.0"
             },
             "peerDependencies": {
-                "oxlint-tsgolint": ">=0.24.0",
+                "oxlint-tsgolint": ">=7.0.2001",
                 "vite-plus": "*"
             },
             "peerDependenciesMeta": {
@@ -7400,6 +7538,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
             "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
                 "@types/unist": "^3.0.0",
@@ -7475,9 +7614,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7494,7 +7633,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -7690,6 +7829,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
             "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "hast-util-raw": "^9.0.0",
@@ -7827,9 +7967,10 @@
             }
         },
         "node_modules/remark-smartypants": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
-            "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+            "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+            "license": "MIT",
             "dependencies": {
                 "retext": "^9.0.0",
                 "retext-smartypants": "^6.0.0",
@@ -7844,6 +7985,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
             "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-to-markdown": "^2.0.0",
@@ -7867,6 +8009,7 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
             "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
                 "retext-latin": "^4.0.0",
@@ -7882,6 +8025,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
             "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
                 "parse-latin": "^7.0.0",
@@ -7911,6 +8055,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
             "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
                 "nlcst-to-string": "^4.0.0",
@@ -7978,9 +8123,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-            "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+            "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -7999,14 +8144,14 @@
             }
         },
         "node_modules/sass-embedded": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.100.0.tgz",
-            "integrity": "sha512-Ut8wlQSk19tm7jMK6mz6cF1+e+E7tUnW2tM02zQDPnOTcVbV8qCQG8UWxZkkNlY50+hV3hqP24OOkUlMz8xBpw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.102.0.tgz",
+            "integrity": "sha512-7xZ7jbsGTpA+oRIJ3HKeiYy+RIrwHltIjKMdnRTAZiPpqvKzwy80zZqR532yk5bpHn1lTqWdZ6Fh4KI+GWSsKA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@bufbuild/protobuf": "^2.5.0",
-                "colorjs.io": "^0.5.0",
+                "colorjs.io": "^0.7.0",
                 "immutable": "^5.1.5",
                 "rxjs": "^7.4.0",
                 "supports-color": "^8.1.1",
@@ -8017,33 +8162,33 @@
                 "sass": "dist/bin/sass.js"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=20.19.0"
             },
             "optionalDependencies": {
-                "sass-embedded-all-unknown": "1.100.0",
-                "sass-embedded-android-arm": "1.100.0",
-                "sass-embedded-android-arm64": "1.100.0",
-                "sass-embedded-android-riscv64": "1.100.0",
-                "sass-embedded-android-x64": "1.100.0",
-                "sass-embedded-darwin-arm64": "1.100.0",
-                "sass-embedded-darwin-x64": "1.100.0",
-                "sass-embedded-linux-arm": "1.100.0",
-                "sass-embedded-linux-arm64": "1.100.0",
-                "sass-embedded-linux-musl-arm": "1.100.0",
-                "sass-embedded-linux-musl-arm64": "1.100.0",
-                "sass-embedded-linux-musl-riscv64": "1.100.0",
-                "sass-embedded-linux-musl-x64": "1.100.0",
-                "sass-embedded-linux-riscv64": "1.100.0",
-                "sass-embedded-linux-x64": "1.100.0",
-                "sass-embedded-unknown-all": "1.100.0",
-                "sass-embedded-win32-arm64": "1.100.0",
-                "sass-embedded-win32-x64": "1.100.0"
+                "sass-embedded-all-unknown": "1.102.0",
+                "sass-embedded-android-arm": "1.102.0",
+                "sass-embedded-android-arm64": "1.102.0",
+                "sass-embedded-android-riscv64": "1.102.0",
+                "sass-embedded-android-x64": "1.102.0",
+                "sass-embedded-darwin-arm64": "1.102.0",
+                "sass-embedded-darwin-x64": "1.102.0",
+                "sass-embedded-linux-arm": "1.102.0",
+                "sass-embedded-linux-arm64": "1.102.0",
+                "sass-embedded-linux-musl-arm": "1.102.0",
+                "sass-embedded-linux-musl-arm64": "1.102.0",
+                "sass-embedded-linux-musl-riscv64": "1.102.0",
+                "sass-embedded-linux-musl-x64": "1.102.0",
+                "sass-embedded-linux-riscv64": "1.102.0",
+                "sass-embedded-linux-x64": "1.102.0",
+                "sass-embedded-unknown-all": "1.102.0",
+                "sass-embedded-win32-arm64": "1.102.0",
+                "sass-embedded-win32-x64": "1.102.0"
             }
         },
         "node_modules/sass-embedded-all-unknown": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.100.0.tgz",
-            "integrity": "sha512-auFtXY/kwYILmSVjtBDwyj0axcLbYYiffOKWoaXHnI5bsYwiRbBh3EneR1rpbX2ZIZCrwX93i5pxKLTZF/662Q==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.102.0.tgz",
+            "integrity": "sha512-BpaRCODYILywdCOI8++Q63+/ptsnWdwYuKyD5gMH0cJblXj85EePdeTTOM7Hl2PP6d4dIojg8GS9fIZhD2x8qA==",
             "cpu": [
                 "!arm",
                 "!arm64",
@@ -8053,13 +8198,13 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "sass": "1.100.0"
+                "sass": "1.102.0"
             }
         },
         "node_modules/sass-embedded-android-arm": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.100.0.tgz",
-            "integrity": "sha512-70f3HgX2pFNmzpGQ86n5e6QfWn2fP4QUQGfFQK0P1XH73ZLIzLo2YqygrGKGKeeqtc5eU2Wl1/xQzhzuKnO4kw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.102.0.tgz",
+            "integrity": "sha512-QM6sPMUtUvFopVR15qXWdobSTYW/sPrXJLxa7eaIbqr/0EtNBZirEXdiOFdDNcsFIEFX3NeZjDq8ZkBAQrxR1w==",
             "cpu": [
                 "arm"
             ],
@@ -8073,9 +8218,9 @@
             }
         },
         "node_modules/sass-embedded-android-arm64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.100.0.tgz",
-            "integrity": "sha512-W+Ru9JwTnfU0UX3jSZcbqFdtKFMcYdfFwytc57h2DgnqCOIiAqI2E06mABZBZC+r3LwXCBuS5GbXAGeVgvVDkA==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.102.0.tgz",
+            "integrity": "sha512-p34iJl04ksTA/6/NZNKv4Bda710hvpoUNUK6vgHKe53tTGhL5XOfYyTjX95lpKPSvGm4BlPEVSSo6CBhyNSDpw==",
             "cpu": [
                 "arm64"
             ],
@@ -8089,9 +8234,9 @@
             }
         },
         "node_modules/sass-embedded-android-riscv64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.100.0.tgz",
-            "integrity": "sha512-icU3o0V/uCSytSpf+tX5Lf51BvyQEbLzDUJfUi9etSauYBGHpPKkdtdZH0si4v98phq11Kl8rSV1SggksxF1Hg==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.102.0.tgz",
+            "integrity": "sha512-wcT5N3B6fIwCKCicDcUP6Jol+e1R3WxHMGU7Swp9Ds9VV8di7HYOKIFcasT25dKJv4l17SA7x5Oum0FlRnMPkg==",
             "cpu": [
                 "riscv64"
             ],
@@ -8105,9 +8250,9 @@
             }
         },
         "node_modules/sass-embedded-android-x64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.100.0.tgz",
-            "integrity": "sha512-mevF9VQk6gEYByy8+jusaHGmd7Usb2ytX/DsEOd0JtOGCtcf1kh575xJ6OUBDIcJ15uLnbau/0iy1eP6WVBvWA==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.102.0.tgz",
+            "integrity": "sha512-IF4eJmoM4uzOborahHp8D4PlCIvumr6IGEbe1XkedwE57qRdk/GENiYZjGwYUQP0uy+pfb+WfvTNhMxkD2VhJg==",
             "cpu": [
                 "x64"
             ],
@@ -8121,9 +8266,9 @@
             }
         },
         "node_modules/sass-embedded-darwin-arm64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.100.0.tgz",
-            "integrity": "sha512-1PVlYi61POo93IT/FfrG1mc1tAHxeSTyUALF2aOFmXGWjVXr3bQzEQiBGCOvQbj/ix+5hNyXFXcEMEyKvtUJJA==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.102.0.tgz",
+            "integrity": "sha512-txaURnQp3L/5mGgSkg6zFrI/H1BgwPxH+7fv/HMuFT1fTXGi7i5++OJNCFVPL7gFB50WFmpf02bCvgec3/gxMA==",
             "cpu": [
                 "arm64"
             ],
@@ -8137,9 +8282,9 @@
             }
         },
         "node_modules/sass-embedded-darwin-x64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.100.0.tgz",
-            "integrity": "sha512-x97o3JnGyImZNCIVs9wQHJUE5QCvmVIKaH1cwrz/5dK7OT1FpeNiW+u9TUomP9hG6Ekjd8EL8NBHpxTfIhdjmg==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.102.0.tgz",
+            "integrity": "sha512-KXs/y/bCVTxRy6NbgC2kK2JwmYnu4+EcDu+DVpHHIfiRgClTca++jYEqcxkthqK9ufkCgwMmrhb3tllyw5l1dw==",
             "cpu": [
                 "x64"
             ],
@@ -8153,9 +8298,9 @@
             }
         },
         "node_modules/sass-embedded-linux-arm": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.100.0.tgz",
-            "integrity": "sha512-9Ul7O1eKrc5YlhwWjkp8tZPSe3UEwSZ1uwUZOQom1HL0pRlBA6F/IlGZYFTLwnHMIP1fc77MMNaBRfc05mKMpw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.102.0.tgz",
+            "integrity": "sha512-1nqC2lrn91fjEsf6gSr/KigU15FrhUSDGWdSWowLXvNG8KbYUNRKjfypn+8u4P0SrL+R/v4VSVZguZiVVTI94A==",
             "cpu": [
                 "arm"
             ],
@@ -8170,9 +8315,9 @@
             }
         },
         "node_modules/sass-embedded-linux-arm64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.100.0.tgz",
-            "integrity": "sha512-Dwjmj8Z6VRy7rAi53JAdEwIyUjpfl7PhpSc2/LpQPQx+aO5Dp7Spaipkax0ufJl1SoDUdchCsM4y/88YaluorQ==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.102.0.tgz",
+            "integrity": "sha512-Yg3Ga1deV+igVqjyK5gHMKbC6fdtKkVYBnzkPVbn/W2/DeActR2JFBfMwVtZJdLpNneMye3dRzOVO2QFegsTbQ==",
             "cpu": [
                 "arm64"
             ],
@@ -8187,9 +8332,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-arm": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.100.0.tgz",
-            "integrity": "sha512-sl0JgbGloPyJg66XXx5UDSDScZ0oU85DpMQU4JU/sCUCFj1Z8zZ69SJWKTCNE4/jwnce7WI2zPCV5AG+RHOZJw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.102.0.tgz",
+            "integrity": "sha512-WULwlrLbhHsJzGBcfztoXK47VyJugcWDmLXF893+yrMj6dF4/zJP6JqootT3EmAx9JAUdAppXI6ma7aGlnV8jw==",
             "cpu": [
                 "arm"
             ],
@@ -8204,9 +8349,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-arm64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.100.0.tgz",
-            "integrity": "sha512-XpACJB2KjSLjf2e9uuvGVdOURsoNrFqgRiihhXyUHK9W0t3LIHb7z5MA/7XGPIT9bWSOO2zyw+rH/FHtDV/Yrg==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.102.0.tgz",
+            "integrity": "sha512-UFvRNJcYFOqo0X525vXG3Buue+waoqiG58xx7J6tMHSj5K/38t+9YbbgppKGLRoKoAwZTIdW8pxPA8qBSzQC6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -8221,9 +8366,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-riscv64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.100.0.tgz",
-            "integrity": "sha512-ShvI0Kx04mwoCARwZ0UjiT97isQvzO80tAt91zmFyHLN9kelc/IrQi940farSm2xQVPCKdeVyeG0ekBsokSpYQ==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.102.0.tgz",
+            "integrity": "sha512-7EmAMt5cX0SEN/qTNHD4VBHyjJXmFMAGuNR9R4YJR/SWGj/OZJw9VWryMfzEnMgNbG6HykiIttGfr9CyNKmZbA==",
             "cpu": [
                 "riscv64"
             ],
@@ -8238,9 +8383,9 @@
             }
         },
         "node_modules/sass-embedded-linux-musl-x64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.100.0.tgz",
-            "integrity": "sha512-TDBCRWNuS4RDLQXvRc1gjZlWiWTWaWGp0Bwu/IKwJxov81lsvrCs3TihTyNXtW7V5aoN4Ky3r0QOkNb3mwmBnA==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.102.0.tgz",
+            "integrity": "sha512-HHzU5/g/MT1edbHfDzZleKcX19l6LMGk0KhZFLy66cxQl1iRLUaL22jfGstmHOdRUmVzWF3VevjSflSGvAjr4Q==",
             "cpu": [
                 "x64"
             ],
@@ -8255,9 +8400,9 @@
             }
         },
         "node_modules/sass-embedded-linux-riscv64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.100.0.tgz",
-            "integrity": "sha512-j4ENJGOheO+fm3j/yorLxCjBP6/XskrZx7dTLlT+lXYwN/qqCqoA/gsNLI0McS3DFM6GBwPiffzWsdWS8t6sEQ==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.102.0.tgz",
+            "integrity": "sha512-AUc4wHQ7IUo9/0mcZQn7Xkl1t1+NZlTF+v5i3GX93HNoQUGIFic7q6qjSERLkdwQ0dLnWrMqe8KhV98V8v0ZoA==",
             "cpu": [
                 "riscv64"
             ],
@@ -8272,9 +8417,9 @@
             }
         },
         "node_modules/sass-embedded-linux-x64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.100.0.tgz",
-            "integrity": "sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.102.0.tgz",
+            "integrity": "sha512-CxfhMwwbQFBCTjGysByvOw4PIOCYZ/jtz9uBU0UR5sfHtQvqqnsNyb1fVCIUsZ7piimxQAwcLV5H3Skj96QiVg==",
             "cpu": [
                 "x64"
             ],
@@ -8289,9 +8434,9 @@
             }
         },
         "node_modules/sass-embedded-unknown-all": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.100.0.tgz",
-            "integrity": "sha512-c+naBgWId4MIpToXcI0DgqetjdAkwTTAxFAuOaBz7HUXLdyG1oZRrEvSsbe41nEdQOKH0vgofVFCeSQgoXOG9A==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.102.0.tgz",
+            "integrity": "sha512-qhqfvFD/7X0c6e5rwvzABkGlaYJju1G+hDPCiB0HdK+S7JF+YDDb9XpRYJ9+tGIopWzEHhoNnJDPtPs9IX1lOQ==",
             "license": "MIT",
             "optional": true,
             "os": [
@@ -8301,13 +8446,13 @@
                 "!win32"
             ],
             "dependencies": {
-                "sass": "1.100.0"
+                "sass": "1.102.0"
             }
         },
         "node_modules/sass-embedded-win32-arm64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.100.0.tgz",
-            "integrity": "sha512-iE+yxj+hUXwwbqpHkXxgAWTzeRfcWxJ7SSTQEPMk48lwq3oCrWLlz5sQuWHbuTK/i0GKQfROdP+hOmPi89yjUg==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.102.0.tgz",
+            "integrity": "sha512-EQOTKStMf7ervyhe3AX10Pa6F7CQMN3IgmpBkfgjy9HQG4Iyt34zCl/4vNJLVBWLW03b7/KJacy2I9SRz26X9g==",
             "cpu": [
                 "arm64"
             ],
@@ -8321,9 +8466,9 @@
             }
         },
         "node_modules/sass-embedded-win32-x64": {
-            "version": "1.100.0",
-            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.100.0.tgz",
-            "integrity": "sha512-qI4F8MI7/KYoy9NdjJfhSspG42WPkADSNDvwEV7qWvCSFC83koJssRsKO2/PfY+niZz6BG65Ic/D+A11h959hw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.102.0.tgz",
+            "integrity": "sha512-e+26mgR+O4g/m7r+WGuvygsjgZEsfgWntIOgaNhkSa9b7vVas70l2RB/SipUM4zGXQk1jX06aOEz0w0Pq1pprQ==",
             "cpu": [
                 "x64"
             ],
@@ -8334,29 +8479,6 @@
             ],
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/satteri": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
-            "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.5",
-                "@types/hast": "^3.0.4",
-                "@types/mdast": "^4.0.4",
-                "@types/unist": "^3.0.3"
-            },
-            "optionalDependencies": {
-                "@bruits/satteri-darwin-arm64": "0.9.5",
-                "@bruits/satteri-darwin-x64": "0.9.5",
-                "@bruits/satteri-linux-arm64-gnu": "0.9.5",
-                "@bruits/satteri-linux-arm64-musl": "0.9.5",
-                "@bruits/satteri-linux-x64-gnu": "0.9.5",
-                "@bruits/satteri-linux-x64-musl": "0.9.5",
-                "@bruits/satteri-wasm32-wasi": "0.9.5",
-                "@bruits/satteri-win32-arm64-msvc": "0.9.5",
-                "@bruits/satteri-win32-x64-msvc": "0.9.5"
             }
         },
         "node_modules/sax": {
@@ -8565,9 +8687,9 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",
@@ -8715,6 +8837,15 @@
             "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
             "license": "MIT"
         },
+        "node_modules/undici": {
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.19.0"
+            }
+        },
         "node_modules/unified": {
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -8734,14 +8865,14 @@
             }
         },
         "node_modules/unifont": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-            "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+            "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
             "license": "MIT",
             "dependencies": {
                 "css-tree": "^3.1.0",
-                "ofetch": "^1.5.1",
-                "ohash": "^2.0.11"
+                "ohash": "^2.0.11",
+                "undici": "^8.0.0"
             }
         },
         "node_modules/unist-util-find-after": {
@@ -8774,6 +8905,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
             "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "array-iterate": "^2.0.0"
@@ -8853,6 +8985,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
             "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -9391,17 +9524,17 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.5.39",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
-            "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+            "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.39",
-                "@vue/compiler-sfc": "3.5.39",
-                "@vue/runtime-dom": "3.5.39",
-                "@vue/server-renderer": "3.5.39",
-                "@vue/shared": "3.5.39"
+                "@vue/compiler-dom": "3.5.41",
+                "@vue/compiler-sfc": "3.5.41",
+                "@vue/runtime-dom": "3.5.41",
+                "@vue/server-renderer": "3.5.41",
+                "@vue/shared": "3.5.41"
             },
             "peerDependencies": {
                 "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
         "format:ci": "oxfmt --check"
     },
     "dependencies": {
-        "@astrojs/mdx": "^7.0.2",
+        "@astrojs/mdx": "7.0.6",
         "bufferutil": "^4.1.0",
-        "dayjs": "^1.11.21",
+        "dayjs": "^1.11.23",
         "medium-zoom": "^1.1.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
@@ -24,14 +24,14 @@
         "sharp": "^0.35.3"
     },
     "devDependencies": {
-        "@astrojs/vue": "^7.0.1",
-        "@iconify/json": "^2.2.498",
-        "astro": "^7.0.7",
-        "globals": "^17.7.0",
-        "oxfmt": "^0.58.0",
-        "oxlint": "^1.73.0",
-        "sass-embedded": "^1.100.0",
+        "@astrojs/vue": "^7.0.2",
+        "@iconify/json": "^2.2.518",
+        "astro": "7.2.3",
+        "globals": "^17.11.0",
+        "oxfmt": "^0.64.0",
+        "oxlint": "^1.79.0",
+        "sass-embedded": "^1.102.0",
         "unplugin-icons": "^23.0.1",
-        "vue": "^3.5.39"
+        "vue": "^3.5.41"
     }
 }


### PR DESCRIPTION
Pinning astro to 7.2.3 as the 7.2.4 upgrade fails with `npm ci` due to missing platform publishes for the transient satteri dependency (https://github.com/bruits/satteri/issues/274)